### PR TITLE
Upgrade flocq dependency to 3.4.2, add automake to dependencies in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains some experimental work on a binary parser and Iris inte
 
 The project comes with an `esy` packaging.
 
-The following programs are assumed to be installed: `git`, `curl`, `m4`, and `autoconf`.
+The following programs are assumed to be installed: `git`, `curl`, `m4`, `autoconf`, and `automake`.
 These programs are used to fetch and compile dependencies.
 
 Installing `esy` itself can be done through `npm`.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"ocaml": "4.8.1000",
 		"@opam/coq": "8.10.1",
 		"@opam/ocamlfind": "1.8.1",
-		"coq-flocq": "3.2.0",
+		"coq-flocq": "3.4.2",
 		"compcert": "github:Mbodin/CompCert#3f06d181874c16887cae0fbc1531631c7a66d275",
 		"@opam/coq-stdpp": "*",
 		"coq-iris": "*",
@@ -63,22 +63,20 @@
 			}
 		},
 		"coq-flocq": {
-			"source": "git:https://gitlab.inria.fr/flocq/flocq.git#a9be51660cd865d323b0b3bbb9faa793856ea0de",
-			"version": "3.2.0",
+			"source": "git:https://gitlab.inria.fr/flocq/flocq.git#ca655d2542bdcf024bce5c26dbc0f13b856aa1f6",
+			"version": "3.4.2",
 			"override": {
-				"dependencies": {
-					"@opam/coq": "8.10.1"
-				},
 				"buildsInSource": true,
 				"buildEnv": {
 					"HOME": "#{self.target_dir}",
 					"COQBIN": "#{@opam/coq.bin}",
 					"COQLIB": "#{@opam/coq.lib}/coq/",
-					"COQPATH": "#{@opam/coq.lib}/coq/user-contrib"
+					"COQPATH": "#{@opam/coq.lib}/coq/user-contrib",
+          "COQUSERCONTRIB": "#{self.install}/coq"
 				},
 				"build": [
-					[ "./autogen.sh" ],
-					[ "./configure", "--libdir=#{self.install}/coq/Flocq" ],
+					[ "autoconf" ],
+					[ "./configure" ],
 					[ "./remake", "--jobs=2" ],
 					[ "./remake", "install" ]
 				]


### PR DESCRIPTION
Hi! In trying to get WasmCert to build on Mac OS X (11.2.3), I ran into a problem with Flocq (https://gitlab.inria.fr/flocq/flocq/-/issues/13) which was fixed in, I think, in the 3.4.0 release (it was reported present in 3.3.1, and promptly fixed). 

Since this project is hardcoding dependencies, I upgraded it all the way to the most current, 3.4.2. 

In doing so, I slightly changed how it is built -- I'm not actually sure how it worked before (I don't see a generated `./autogen.sh` at the given commit hash but maybe I missed something), but `autoconf` followed by `./configure` and then `./remake` and `./remake install` is what the documentation specifies to do, and it works, once the directory to install to is set via the environment variable `COQUSERCONTRIB` (what the documentation currently says to do), rather than passing to `./configure` (which no longer seems to do anything).

Finally, Flocq says it supports coq 8.7 all the way to current (8.13), so I got rid of the specified dependency on a particular version of coq, as it seemed unnecessary.

(While I was doing this, I added the `automake` dependency to those listed in the readme. One of the dependencies uses `autoconf` in a way that invokes `aclocal` which comes from `automake`, so you need both packages...).