### PR TITLE
major improvements and refactors on typing inversion tactic and lemmas

### DIFF
--- a/theories/instantiation_properties.v
+++ b/theories/instantiation_properties.v
@@ -902,23 +902,15 @@ Proof.
   { apply empty_typing in Hbet. by subst. }
   { apply empty_typing in Hbet. by subst. }
   { rewrite <- cat1s in Hbet.
-    apply composition_typing in Hbet.
-    destruct Hbet as [ts [t1s [t2s [t3s [-> [Heqt2 [Hbet1 Hbet2]]]]]]].
-    destruct ts, t2s => //=.
+    invert_be_typing; subst.
+    destruct ts1_comp, ts3_comp => //; clear H2_comp.
     simpl in Hconst.
     move/andP in Hconst.
     destruct Hconst as [Hconst Hconsts].
-    apply IHes in Hbet2 => //.
-    destruct es, t3s => //=.
+    apply IHes in H4_comp => //.
+    destruct es, ts4_comp => //=.
     unfold const_expr in Hconst.
-    destruct a => //.
-    { apply (Get_global_typing host_instance) in Hbet1.
-      destruct Hbet1 as [t [? [HContra ?]]].
-      by destruct t1s.
-    }
-    { apply BI_const_typing in Hbet1.
-      by destruct t1s.
-    }
+    destruct a => //; invert_be_typing; by destruct ts2_comp.
   }
   { rewrite <- cat1s in Hbet.
     apply composition_typing in Hbet.
@@ -932,20 +924,7 @@ Proof.
       by lias.
     }
     unfold const_expr in Hconst.
-    destruct a => //.
-    { apply (Get_global_typing host_instance) in Hbet1.
-      destruct Hbet1 as [t [? [HContra ?]]].
-      subst.
-      rewrite -> app_length in *.
-      simpl in *.
-      by lias.
-    }
-    { apply BI_const_typing in Hbet1.
-      subst.
-      rewrite -> app_length in *.
-      simpl in *.
-      by lias.
-    }
+    destruct a => //; invert_be_typing; rewrite -> app_length in *; simpl in *; by lias.
   }
 Qed.
   

--- a/theories/instantiation_sound.v
+++ b/theories/instantiation_sound.v
@@ -956,7 +956,7 @@ Proof.
                eapply Forall2_lookup in HGlobType; last by apply Hglobs_nth.
                destruct HGlobType as [y [Hnth [Hconst [-> Hbet]]]].
 
-               specialize (const_exprs_impl host_function host_instance _ _ _ Hconst Hbet) as Hexprs.
+               specialize (const_exprs_impl _ _ _ Hconst Hbet) as Hexprs.
                clear Hconst.
                destruct Hexprs as [expr [-> Hconst]]; remove_bools_options.
                rewrite /const_expr in Hconst. simpl in Hconst.

--- a/theories/interp_instantiate_sound.v
+++ b/theories/interp_instantiate_sound.v
@@ -376,7 +376,7 @@ Lemma interp_get_i32_reduce: forall hs s c inst k bes,
 Proof.
   move => hs s c inst bes k Hconst Hbet Heval.
   unfold interp_get_i32, interp_get_v in Heval.
-  eapply const_exprs_impl in Hconst; eauto; last exact host_instance.
+  eapply const_exprs_impl in Hconst; eauto.
   destruct Hconst as [be [-> Hconst]].
   destruct be => //=.
   - simpl in Heval.
@@ -477,7 +477,7 @@ Proof.
     move/andP in Hmodcheck.
     destruct Hmodcheck as [Hconstexpr Hbetype].
     move/b_e_type_checker_reflects_typing in Hbetype.
-    eapply const_exprs_impl in Hconstexpr; [ | instantiate (1 := host_function_eqType); exact host_instance | by eauto].
+    eapply const_exprs_impl in Hconstexpr; last by eauto.
     destruct Hconstexpr as [e [-> Hconst]].
     unfold const_expr in Hconst.
     destruct e => //.

--- a/theories/interpreter_func.v
+++ b/theories/interpreter_func.v
@@ -404,8 +404,8 @@ Proof.
   intros s f ves Heqves [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply_cat0_inv Ht1s.
-  apply Drop_typing in Hbtype as [??]. by destruct t2s.
+  simpl in Hbtype; invert_be_typing.
+  by apply_cat0_inv Ht1s.
 Qed.
 
 Lemma reduce_select_false : forall (hs : host_state) s f c v2 v1 ves',
@@ -444,11 +444,10 @@ Proof.
   intros s f v3 v2 v1 ves ves' Hv Heqves [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply Select_typing in Hbtype as [? [? [??]]]. subst t1s t2s.
-
-  (* TODO move this into the ltac? *)
-  replace ([:: x0; x0; T_i32]) with ([:: x0; x0] ++ [:: T_i32]) in Ht1s => //.
-  by cats1_last_eq Ht1s.
+  simpl in Hbtype; invert_be_typing.
+  apply (f_equal rev) in Ht1s.
+  rewrite revK rev_cat rev_cat in Ht1s; simpl in Ht1s.
+  by inversion Ht1s.
 Qed.
 
 Lemma select_error_size : forall s f ves,
@@ -457,8 +456,8 @@ Lemma select_error_size : forall s f ves,
 Proof.
   intros s f ves ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply Select_typing in Hbtype as [ts [? [??]]].
-  subst t1s t2s.
+  simpl in Hbtype; invert_be_typing.
+  subst.
   by size_unequal Ht1s.
 Qed.
 
@@ -498,8 +497,8 @@ Lemma block_error : forall s f ves bt1s bt2s es,
 Proof.
   intros s f ves bt1s bt2s es ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Block_typing host_instance) in Hbtype as [ts [? [??]]] => //.
-  subst t1s. by size_unequal Ht1s.
+  simpl in Hbtype; invert_be_typing.
+  subst. by size_unequal Ht1s.
 Qed.
 
 Lemma reduce_loop : forall (hs : host_state) s f ves ves' ves'' t1s t2s es,
@@ -548,8 +547,8 @@ Lemma loop_error : forall s f ves lt1s lt2s es,
 Proof.
   intros s f ves lt1s lt2s es Hlen [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Loop_typing host_instance) in Hbtype as [ts [? [??]]] => //.
-  subst t1s t2s. by size_unequal Ht1s.
+  simpl in Hbtype; invert_be_typing.
+  subst. by size_unequal Ht1s.
 Qed.
 
 Lemma reduce_if_false : forall (hs : host_state) s f c ves ves' tf es1 es2,
@@ -591,7 +590,7 @@ Proof.
   intros s f ves tf es1 es2 ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves. destruct tf.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply If_typing in Hbtype as [? [? [? [??]]]]. subst t1s.
+  simpl in Hbtype; invert_be_typing.
   by size_unequal Ht1s.
 Qed.
 
@@ -603,7 +602,7 @@ Proof.
   intros s f v ves ves' tf es1 es2 ?? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves. destruct tf.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply If_typing in Hbtype as [? [? [? [??]]]]. subst t1s.
+  simpl in Hbtype; invert_be_typing.
   by cats1_last_eq Ht1s.
 Qed.
 
@@ -662,7 +661,7 @@ Proof.
   intros s f ves j ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply Br_if_typing in Hbtype as [ts [ts' [? [? [??]]]]]. subst t1s t2s.
+  simpl in Hbtype; invert_be_typing.
   by apply_cat0_inv Ht1s.
 Qed.
 
@@ -674,7 +673,7 @@ Proof.
   intros s f v ves ves' j ?? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply Br_if_typing in Hbtype as [? [? [? [? [??]]]]]. subst t1s t2s.
+  simpl in Hbtype; invert_be_typing.
   by cats1_last_eq Ht1s.
 Qed.
 
@@ -714,7 +713,7 @@ Proof.
   intros s f ves js j ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply Br_table_typing in Hbtype as [ts [ts' [??]]]. subst t1s.
+  simpl in Hbtype; invert_be_typing.
   by apply_cat0_inv Ht1s.
 Qed.
 
@@ -728,7 +727,7 @@ Proof.
   intros s f c ves ves' k js j ??? Hkth [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves k.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply Br_table_typing in Hbtype as [? [? [??]]]. subst t1s.
+  simpl in Hbtype; invert_be_typing.
   apply List.nth_error_None in Hkth.
   by lias.
 Qed.
@@ -763,9 +762,8 @@ Lemma call_error : forall (hs : host_state) s f ves j,
 Proof.
   intros s f v ves j Hjth [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Call_typing host_instance) in Hbtype as [? [t1s'' [t2s'' [? [? [??]]]]]].
-  apply func_context_store with (j := j) (x := Tf t1s'' t2s'') in Hitype
-    as [? Hjth'] => //; try by subst C.
+  simpl in Hbtype; invert_be_typing.
+  eapply func_context_store in Hitype as [? Hjth']; eauto.
   by rewrite Hjth' in Hjth.
 Qed.
 
@@ -820,8 +818,8 @@ Lemma call_indirect_error_0 : forall s f ves j,
 Proof.
   intros s f ves j ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]]. subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Call_indirect_typing host_instance) in Hbtype as [? [? [? [? [? [? [??]]]]]]].
-  subst t1s. by size_unequal Ht1s.
+  simpl in Hbtype; invert_be_typing.
+  by size_unequal Ht1s.
 Qed.
 
 Lemma call_indirect_error_typeof : forall s f v ves ves' j,
@@ -831,8 +829,8 @@ Lemma call_indirect_error_typeof : forall s f v ves ves' j,
 Proof.
   intros s f v ves ves' j Hv ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]]. subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Call_indirect_typing host_instance) in Hbtype as [? [? [? [? [? [? [??]]]]]]].
-  subst t1s. by cats1_last_eq Ht1s.
+  simpl in Hbtype; invert_be_typing.
+  by cats1_last_eq Ht1s.
 Qed.
 
 Lemma call_indirect_error_ath : forall s f c ves ves' j a,
@@ -843,7 +841,7 @@ Lemma call_indirect_error_ath : forall s f c ves ves' j a,
 Proof.
   intros s f c ves ves' j a ?? Hath [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]]. subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Call_indirect_typing host_instance) in Hbtype as [? [? [? [? [? [? [??]]]]]]].
+  simpl in Hbtype; invert_be_typing.
   eapply store_typing_stabaddr with (a := a) (c := Wasm_int.nat_of_uint i32m c) in Hitype as [? Hath'] => //.
   by rewrite Hath in Hath'.
 Qed.
@@ -870,7 +868,7 @@ Proof.
   (* TODO rename Hitype to Hitype everywhere *)
   intros s f ves j Hjth ? [C [C' [ret [lab [t1s [t2s [t1s' [? [? [? [? Hetype]]]]]]]]]]].
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Get_local_typing host_instance) in Hbtype as [? [Hjth' [??]]].
+  simpl in Hbtype; invert_be_typing.
   by apply List.nth_error_None in Hjth; lias.
 Qed.
 
@@ -881,8 +879,9 @@ Proof.
   intros s f ves j Hlen [C [C' [ret [lab [t1s [t2s [t1s' [? [? [? [? Hetype]]]]]]]]]]].
   subst C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Get_local_typing host_instance) in Hbtype as [? [? [? Hlen']]].
-  by rewrite List.map_length in Hlen'; lias.
+  simpl in Hbtype; invert_be_typing.
+  simpl in *.
+  by rewrite List.map_length in H3_getlocal; lias.
 Qed.
 
 Lemma reduce_set_local : forall (hs : host_state) s f f' v ves ves' j,
@@ -907,7 +906,7 @@ Proof.
   intros hs s f ves j ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]]. subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
   apply_cat0_inv Ht1s.
-  apply (Set_local_typing host_instance) in Hbtype as [? [? [??]]].
+  simpl in Hbtype; invert_be_typing.
   by destruct t2s => //.
 Qed.
 
@@ -919,8 +918,8 @@ Proof.
   intros hs s f v ves ves' j ? Hlen [C [C' [ret [lab [t1s [t2s [t1s' [? [? [? [? Hetype]]]]]]]]]]].
   subst ves C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Set_local_typing host_instance) in Hbtype as [? [? [? Hlen']]].
-  by rewrite List.map_length in Hlen'; lias.
+  simpl in Hbtype; invert_be_typing.
+  by rewrite List.map_length in H3_setlocal; lias.
 Qed.
 
 Lemma reduce_tee_local : forall (hs : host_state) s f v ves ves' j,
@@ -944,8 +943,8 @@ Lemma tee_local_error_0 : forall (hs : host_state) s f ves j,
 Proof.
   intros hs s f ves j ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]]. subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply_cat0_inv Ht1s.
-  by apply Tee_local_typing in Hbtype as [[|] [? [? [? [??]]]]] => //.
+  simpl in Hbtype; invert_be_typing.
+  by apply_cat0_inv Ht1s.
 Qed.
 
 Lemma reduce_get_global : forall (hs : host_state) s f ves j xx,
@@ -967,8 +966,9 @@ Lemma get_global_error : forall (hs : host_state) s f ves j,
 Proof.
   intros hs s f ves j Hjth [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Get_global_typing host_instance) in Hbtype as [t [Hjth' [??]]].
-  destruct (List.nth_error (tc_global C) j) eqn:Heqg; subst C => //.
+  simpl in Hbtype; invert_be_typing.
+  simpl in *.
+  destruct (List.nth_error (tc_global C') j) eqn:Heqg => //.
   eapply glob_context_store with (j := j) in Hitype => //;
     last by (rewrite Heqg; f_equal).
   unfold sglob_val, option_map in Hjth.
@@ -997,7 +997,7 @@ Proof.
   intros hs s f ves j ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]]. subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
   apply_cat0_inv Ht1s.
-  apply (Set_global_typing host_instance) in Hbtype as [? [? [? [? [? [??]]]]]].
+  simpl in Hbtype; invert_be_typing.
   by destruct t2s => //.
 Qed.
 
@@ -1009,8 +1009,8 @@ Proof.
   intros hs s f v ves ves' j ? Hjth [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   subst ves C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Set_global_typing host_instance) in Hbtype as [g [? [Hjth' [? [? [??]]]]]].
-  apply glob_context_store with (j := j) (g := g) in Hitype => //.
+  simpl in Hbtype; invert_be_typing.
+  apply glob_context_store with (j := j) (g := g_setglobal) in Hitype => //.
   unfold sglob in Hitype. unfold option_bind in Hitype.
   unfold supdate_glob in Hjth. unfold option_bind in Hjth.
   destruct (sglob_ind s f.(f_inst) j) eqn:? => //.
@@ -1087,7 +1087,8 @@ Proof.
   intros s f ves t tp_sx a off ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves. apply_cat0_inv Ht1s.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  by apply (Load_typing host_instance) in Hbtype as [[|] [? [? [??]]]].
+  simpl in Hbtype; invert_be_typing.
+  by destruct ts_load.
 Qed.
 
 Lemma load_error_typeof : forall s f v ves ves' t tp_sx a off,
@@ -1098,7 +1099,7 @@ Proof.
   intros s f v ves ves' t tp_sx a off Hv ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Load_typing host_instance) in Hbtype as [? [? [? [??]]]]. subst t1s t2s.
+  simpl in Hbtype; invert_be_typing.
   by cats1_last_eq Ht1s.
 Qed.
 
@@ -1111,7 +1112,7 @@ Proof.
   intros s f ves ves' c t tp_sx a off j ? Hsmem Hjth [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   subst ves C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Load_typing host_instance) in Hbtype as [? [? [? [??]]]].
+  simpl in Hbtype; invert_be_typing.
   apply mem_context_store in Hitype as [j' [Hsmem' Hjth']] => //.
   rewrite Hsmem in Hsmem'. injection Hsmem' as Hsmem'. subst j'.
   by apply Hjth'.
@@ -1125,7 +1126,7 @@ Proof.
   intros s f ves ves' c t tp_sx a off ? Hsmem [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   subst ves C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Load_typing host_instance) in Hbtype as [? [? [? [??]]]].
+  simpl in Hbtype; invert_be_typing.
   apply mem_context_store in Hitype as [? [Hsmem' ?]] => //.
   by rewrite Hsmem' in Hsmem.
 Qed.
@@ -1205,8 +1206,8 @@ Lemma store_error_size : forall s f ves t tp a off,
 Proof.
   intros s f ves t tp a off ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Store_typing host_instance) in Hbtype as [? [??]].
-  subst t1s. by size_unequal Ht1s.
+  simpl in Hbtype; invert_be_typing.
+  subst. by size_unequal Ht1s.
 Qed.
 
 Lemma store_error_typeof : forall s f v v' ves ves' t tp a off,
@@ -1217,8 +1218,8 @@ Proof.
   intros s f v v' ves ves' t tp a off ?? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Store_typing host_instance) in Hbtype as [? [??]].
-  subst t1s.
+  simpl in Hbtype; invert_be_typing.
+  subst.
   (* TODO move this into the ltac? *)
   replace [:: T_i32; t] with ([:: T_i32] ++ [:: t]) in Ht1s => //.
   by repeat cats1_last_eq Ht1s.
@@ -1232,8 +1233,8 @@ Proof.
   intros s f v c ves ves' t tp a off ?? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Store_typing host_instance) in Hbtype as [? [??]].
-  subst t1s.
+  simpl in Hbtype; invert_be_typing.
+  subst.
   replace [:: T_i32; t] with ([:: T_i32] ++ [:: t]) in Ht1s => //.
   cats1_last_eq Ht1s. by destruct v, t => //.
 Qed.
@@ -1249,7 +1250,7 @@ Proof.
     [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   subst ves C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Store_typing host_instance) in Hbtype as [? [??]].
+  simpl in Hbtype; invert_be_typing.
   apply mem_context_store in Hitype as [j' [Hsmem' Hjth']] => //.
   (* TODO this repeats elsewhere -- make a lemma / ltac? *)
   rewrite Hsmem in Hsmem'. injection Hsmem' as Hsmem'. subst j'.
@@ -1265,7 +1266,7 @@ Proof.
   intros s f v c ves ves' t tp a off ?? Hsmem [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   subst ves C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Store_typing host_instance) in Hbtype as [? [??]].
+  simpl in Hbtype; invert_be_typing.
   apply mem_context_store in Hitype as [? [Hsmem' ?]] => //.
   by rewrite Hsmem in Hsmem'.
 Qed.
@@ -1293,7 +1294,7 @@ Proof.
   intros s f ves j Hsmem ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   subst C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Current_memory_typing host_instance) in Hbtype as [??] => //.
+  simpl in Hbtype; invert_be_typing.
   apply mem_context_store in Hitype as [j' [Hsmem' Hjth]] => //.
   rewrite Hsmem' in Hsmem. injection Hsmem as Hsmem. subst j'.
   by apply Hjth.
@@ -1306,7 +1307,7 @@ Proof.
   intros s f ves Hsmem [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   subst C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Current_memory_typing host_instance) in Hbtype as [??] => //.
+  simpl in Hbtype; invert_be_typing.
   apply mem_context_store in Hitype as [? [Hsmem' ?]] => //.
   by rewrite Hsmem' in Hsmem.
 Qed.
@@ -1364,7 +1365,7 @@ Proof.
   intros s f ves ves' j c ? Hsmem ? [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   subst ves C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Grow_memory_typing host_instance) in Hbtype as [? [? [??]]] => //.
+  simpl in Hbtype; invert_be_typing.
   apply mem_context_store in Hitype as [j' [Hsmem' Hjth]] => //.
   rewrite Hsmem' in Hsmem. injection Hsmem as Hsmem. subst j'.
   by apply Hjth.
@@ -1378,7 +1379,7 @@ Proof.
   intros s f ves ves' c ? Hsmem [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [Hitype [? Hetype]]]]]]]]]]].
   subst ves C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Grow_memory_typing host_instance) in Hbtype as [? [? [??]]] => //.
+  simpl in Hbtype; invert_be_typing.
   apply mem_context_store in Hitype as [? [Hsmem' ?]] => //.
   by rewrite Hsmem' in Hsmem.
 Qed.
@@ -1391,7 +1392,7 @@ Proof.
   intros s f v ves ves' Hv Heqves [C [C' [ret [lab [t1s [t2s [t1s' [? [Ht1s [? [? Hetype]]]]]]]]]]].
   subst ves C.
   apply et_to_bet in Hetype as Hbtype; last by auto_basic.
-  apply (Grow_memory_typing host_instance) in Hbtype as [? [? [??]]] => //. subst t1s t2s.
+  simpl in Hbtype; invert_be_typing.
   by cats1_last_eq Ht1s.
 Qed.
 
@@ -1857,14 +1858,14 @@ Proof.
       as [? [t0s [ts' [t1s' [Ht0s [Hts'' [Hetypebvs Hetypebr]]]]]]].
   apply_cat0_inv Ht0s; simpl in *; subst.
   apply et_to_bet in Hetypebr; last by auto_basic.
-  apply (Break_typing host_instance) in Hetypebr
-    as [ts'0 [ts'' [Hj [Hplop' Heqt1s']]]].
-  assert (ts'0 = t_br).
+  simpl in Hetypebr; invert_be_typing.
+  assert (t_br = ts_br).
   {
-    unfold plop2 in Hplop, Hplop'. move/eqP in Hplop. move/eqP in Hplop'.
-    rewrite Hplop' in Hplop. by injection Hplop.
+    unfold plop2 in *.
+    remove_bools_options.
+    by rewrite Hplop in H2_br; injection H2_br.
   }
-  subst ts'0 t1s'.
+  subst.
   apply et_to_bet in Hetypebvs;
     last by apply const_list_is_basic; apply v_to_e_is_const_list.
   apply Const_list_typing in Hetypebvs.
@@ -2024,7 +2025,7 @@ Proof.
     apply e_composition_typing in Hetype as [? [? [? [? [-> [-> [Hetype _]]]]]]].
     apply e_composition_typing in Hetype as [? [? [? [? [-> [-> [_ Hetypebr]]]]]]].
     apply et_to_bet in Hetypebr; last by auto_basic.
-    by apply (Break_typing host_instance) in Hetypebr as [? [? [Hj [??]]]]; auto.
+    by simpl in Hetypebr; invert_be_typing.
   - subst i k vs0 m' es'0 lh'0 es''0 es0 es.
     apply e_composition_typing in Hetype as [? [t0s [? [t1s' [-> [-> [_ Hetype]]]]]]].
     apply e_composition_typing in Hetype as [? [t1s [? [t2s' [-> [-> [Hetype _]]]]]]].
@@ -2131,9 +2132,8 @@ Proof.
       as [? [t0s [ts' [t1s' [Ht0s [Hts'' [Hetypervs Hetyperet]]]]]]].
   apply_cat0_inv Ht0s; simpl in *; subst.
   apply et_to_bet in Hetyperet; last by auto_basic.
-  apply (Return_typing host_instance) in Hetyperet
-      as [ts'0 [ts'' [Heqt0s Heqts'0]]].
-  rewrite Heqts'0 in Heqret.
+  simpl in Hetyperet; invert_be_typing.
+  rewrite H2_return in Heqret.
   injection Heqret; subst; clear Heqret.
   move => <-.
   apply et_to_bet in Hetypervs;

--- a/theories/type_preservation.v
+++ b/theories/type_preservation.v
@@ -92,7 +92,6 @@ Proof.
   destruct tf as [ts1 ts2].
   inversion HReduce; b_to_a_revert; subst.
   invert_be_typing.
-  rewrite catA in H1. apply concat_cancel_last in H1. destruct H1; subst.
   repeat rewrite catA.
   apply bet_weakening_empty_1.
   apply app_binop_type_preserve in H0.
@@ -139,11 +138,8 @@ Proof.
   destruct tf as [ts1 ts2].
   inversion HReduce; subst.
   invert_be_typing.
-  replace ([::t;t]) with ([::t] ++ [::t]) in H2 => //.
-  rewrite catA in H2.
-  apply concat_cancel_last in H2. destruct H2 as [H3 H4]. subst.
-  rewrite catA in H1.
-  apply concat_cancel_last in H1. destruct H1 as [H5 H6]. subst.
+  replace ([::t;t]) with ([::t] ++ [::t]) in H1_relop => //.
+  invert_be_typing.
   repeat rewrite catA.
   apply bet_weakening_empty_1.
   by apply bet_const.
@@ -223,7 +219,7 @@ Proof.
     gen_ind_subst HType => //=.
     + (* Composition *)
       invert_be_typing.
-      apply concat_cancel_last_n in H1 => //.
+      apply concat_cancel_last_n in H1_select => //.
       remove_bools_options.
       inversion H2. subst.
       apply bet_weakening_empty_1.
@@ -233,7 +229,7 @@ Proof.
     gen_ind_subst HType => //=.
     + (* Composition *)
       invert_be_typing.
-      apply concat_cancel_last_n in H2 => //.
+      apply concat_cancel_last_n in H1_select => //.
       remove_bools_options.
       inversion H3. subst.
       apply bet_weakening_empty_1.
@@ -253,7 +249,6 @@ Proof.
     gen_ind_subst HType => //=.
     + (* Composition *)
       invert_be_typing.
-      rewrite catA in H1. apply concat_cancel_last in H1. destruct H1. subst.
       apply bet_weakening.
       by apply bet_block.
     + (* Weakening *)
@@ -263,7 +258,6 @@ Proof.
     gen_ind_subst HType => //=.
     + (* Composition *)
       invert_be_typing.
-      rewrite catA in H2. apply concat_cancel_last in H2. destruct H2. subst.
       apply bet_weakening.
       by apply bet_block.
     + (* Weakening *)
@@ -314,11 +308,10 @@ Proof.
   (* in range *)
   - dependent induction HType => //=.
     + (* Composition *)
-      invert_be_typing.
-      rewrite catA in H0. apply concat_cancel_last in H0. destruct H0. subst.
-      move/allP in H2.
-      assert (HInd: (j < length (tc_label C)) && plop2 C j ts').
-      -- apply H2. rewrite mem_cat. apply/orP. left. apply/inP.
+      invert_be_typing. subst.
+      move/allP in H2_brtable.
+      assert (HInd: (j < length (tc_label C)) && plop2 C j ts'_brtable).
+      -- apply H2_brtable. rewrite mem_cat. apply/orP. left. apply/inP.
          eapply List.nth_error_In. by eauto.
       remove_bools_options.
       by apply bet_br => //.
@@ -328,11 +321,10 @@ Proof.
   (* out of range *)
   - dependent induction HType => //=.
     + (* Composition *)
-      invert_be_typing.
-      rewrite catA in H1. apply concat_cancel_last in H1. destruct H1. subst.
-      move/allP in H2.
-      assert (HInd: (i0 < length (tc_label C)) && plop2 C i0 ts').
-      -- apply H2. rewrite mem_cat. apply/orP. right. by rewrite mem_seq1.
+      invert_be_typing. subst.
+      move/allP in H2_brtable.
+      assert (HInd: (i0 < length (tc_label C)) && plop2 C i0 ts'_brtable).
+      -- apply H2_brtable. rewrite mem_cat. apply/orP. right. by rewrite mem_seq1.
       remove_bools_options.
       by apply bet_br => //.
     + (* Weakening *)
@@ -345,14 +337,14 @@ Lemma t_Tee_local_preserve: forall C v i tf,
     be_typing C [::BI_const v; BI_const v; BI_set_local i] tf.
 Proof.
   move => C v i tf HType.
-  dependent induction HType => //.
+  gen_ind_subst HType => //=.
   - (* Composition *)
     invert_be_typing.
     replace ([::BI_const v; BI_const v; BI_set_local i]) with ([::BI_const v] ++ [::BI_const v] ++ [::BI_set_local i]) => //.
     repeat (try rewrite catA; eapply bet_composition) => //.
-    + instantiate (1 := (ts ++ [::typeof v])).
+    + instantiate (1 := (ts_teelocal ++ [::typeof v])).
       apply bet_weakening_empty_1. by apply bet_const.
-    + instantiate (1 := (ts ++ [::typeof v] ++ [::typeof v])).
+    + instantiate (1 := (ts_teelocal ++ [::typeof v] ++ [::typeof v])).
       apply bet_weakening. apply bet_weakening_empty_1. by apply bet_const.
     + apply bet_weakening. apply bet_weakening_empty_2. by apply bet_set_local.
   - (* Weakening *)
@@ -505,7 +497,7 @@ Proof.
     destruct HType as [ts [t1s' [t2s' [t3s [H2 [H3 [H4 H5]]]]]]]. subst.
     apply const_es_exists in H. destruct H. subst.
     apply Const_list_typing in H4. subst.
-    apply (Block_typing host_instance) in H5.
+    apply Block_typing in H5.
     destruct H5 as [t3s [H6 [H7 H8]]].
     subst.
     repeat rewrite length_is_size in H1. rewrite v_to_e_size in H1.
@@ -543,7 +535,7 @@ Proof.
     destruct HType as [ts [t1s' [t2s' [t3s [H2 [H3 [H4 H5]]]]]]]. subst.
     apply const_es_exists in H. destruct H. subst.
     apply Const_list_typing in H4. subst.
-    apply (Loop_typing host_instance) in H5.
+    apply Loop_typing in H5.
     destruct H5 as [t3s [H6 [H7 H8]]]. subst.
     repeat rewrite length_is_size in H1. rewrite v_to_e_size in H1.
     assert ((t1s' == t3s) && ((vs_to_vts x) == t1s)) => //=.
@@ -572,7 +564,7 @@ Proof.
     et_dependent_ind HType => //; try by (inversion Hremtf; subst; apply ety_weakening; eapply IHHType).
     + (* ety_a *)
       assert (es_is_basic (operations.to_e_list bes)); first by apply to_e_list_basic.
-      rewrite Hremes in H1. by basic_inversion'.
+      rewrite Hremes in H1. by basic_inversion.
     + (* ety_composition *)
       apply extract_list1 in Hremes. destruct Hremes. subst.
       apply et_to_bet in HType1 => //.
@@ -588,7 +580,7 @@ Proof.
     et_dependent_ind HType => //; try by (inversion Hremtf; subst; apply ety_weakening; eapply IHHType).
     + (* ety_a *)
       assert (es_is_basic (operations.to_e_list bes)); first by apply to_e_list_basic.
-      rewrite Hremes in H2. by basic_inversion'.
+      rewrite Hremes in H2. by basic_inversion.
     + (* ety_composition *)
       apply extract_list1 in Hremes. destruct Hremes. subst.
       apply et_to_bet in HType1 => //.
@@ -610,7 +602,7 @@ Proof.
     et_dependent_ind HType => //; try by (inversion Hremtf; subst; apply ety_weakening; eapply IHHType).
     + (* ety_a *)
       assert (es_is_basic (operations.to_e_list bes)); first by apply to_e_list_basic.
-      rewrite Hremes in H1. by basic_inversion'.
+      rewrite Hremes in H1. by basic_inversion.
     + (* ety_composition *)
       apply extract_list1 in Hremes. destruct Hremes. subst.
       apply et_to_bet in HType1 => //.
@@ -918,7 +910,6 @@ Proof.
   - by eapply tab_extension_C; eauto.
   - by eapply mem_extension_C; eauto.
 Qed.
-
 
 Lemma frame_typing_extension: forall s s' f C,
     store_extension s s' ->
@@ -1592,55 +1583,48 @@ Proof.
     apply composition_typing in HType.
     destruct HType as [ts [t1s [t2s [t3s [H1 [H2 [H3 H4]]]]]]]. subst.
     invert_be_typing.
-    apply (Set_global_typing host_instance) in H4.
-    destruct H4 as [g [t [H5 [H6 [H7 [H8 H9]]]]]].
-    apply concat_cancel_last in H8. destruct H8. subst.
     unfold supdate_glob in H.
     unfold option_bind in H.
     unfold supdate_glob_s in H.
     unfold option_map in H.
     assert (store_extension s s') as Hext.
-    remove_bools_options.
-    unfold sglob_ind in Hoption. simpl in H5.
-    eapply tc_reference_glob_type in H5; eauto.
-    destruct g => //.
-    destruct g0 => //.
-    simpl in H1. unfold global_agree in H5. simpl in H5.
-    unfold is_mut in H7. simpl in H7. remove_bools_options. subst.
-    + simpl. unfold store_extension => //=.
+    { remove_bools_options.
+      unfold sglob_ind in Hoption.
+      eapply tc_reference_glob_type in HIT; eauto.
+      destruct g, g_setglobal => //.
+      unfold global_agree in HIT. simpl in *.
+      unfold is_mut in H3_setglobal. simpl in H3_setglobal. remove_bools_options. subst.
+      simpl. unfold store_extension => //=.
       repeat (apply/andP; split) => //=.
-      -- by rewrite length_is_size take_size; apply all2_func_extension_same.
-      -- by rewrite length_is_size take_size; apply all2_tab_extension_same.
-      -- by rewrite length_is_size take_size; apply all2_mem_extension_same.
-      -- by erewrite nth_error_set_nth_length; eauto.
-      -- match goal with
-         | |- context [take ?n ?l] => remember l as l'
-         | _ => idtac
-         end.
-         assert (length l' = length s.(s_globals)) as Hlen.
-         { subst l'.
-           by erewrite nth_error_set_nth_length; eauto.
-         }
-         rewrite - Hlen.
-         rewrite length_is_size take_size.
-         subst l'.
-         eapply glob_extension_update_nth; eauto => //=.
-         unfold glob_extension => //=.
-         by destruct v => //=; destruct g_val => //=.
-      split => //.
-      by eapply store_global_extension_store_typed; eauto;
-      destruct s => //=; destruct s' => //=; remove_bools_options.
+      - by rewrite length_is_size take_size; apply all2_func_extension_same.
+      - by rewrite length_is_size take_size; apply all2_tab_extension_same.
+      - by rewrite length_is_size take_size; apply all2_mem_extension_same.
+      - by erewrite nth_error_set_nth_length; eauto.
+      - match goal with
+        | |- context [take ?n ?l] => remember l as l'
+        | _ => idtac
+        end.
+        assert (length l' = length s.(s_globals)) as Hlen.
+        { subst l'.
+          by erewrite nth_error_set_nth_length; eauto.
+        }
+        rewrite - Hlen.
+        rewrite length_is_size take_size.
+        subst l'.
+        eapply glob_extension_update_nth; eauto => //=.
+        unfold glob_extension => //=.
+        by destruct v => //=; destruct g_val => //=.
+    }
+    split => //.
+    by eapply store_global_extension_store_typed; eauto;
+    destruct s => //=; destruct s' => //=; remove_bools_options.
   - (* update memory : store none *)
     apply et_to_bet in HType; auto_basic. simpl in HType.
     replace [::BI_const (VAL_int32 k); BI_const v; BI_store t None a off] with ([::BI_const (VAL_int32 k); BI_const v] ++ [::BI_store t None a off]) in HType => //.
     apply composition_typing in HType.
     destruct HType as [ts [t1s [t2s [t3s [H3 [H4 [H5 H6]]]]]]]. subst.
     invert_be_typing.
-    apply (Store_typing host_instance) in H6.
-    destruct H6 as [H7 [H8 H9]]. subst.
-    apply concat_cancel_last_n in H7 => //.
     remove_bools_options.
-    inversion H4. subst. clear H4.
     assert (store_extension s (upd_s_mem s (set_nth mem' (s_mems s) i mem'))) as Hext.
     { eapply store_extension_mem => //; first by rewrite H1.
       by eapply mem_extension_store; eauto.
@@ -1657,7 +1641,7 @@ Proof.
     inversion H0; subst. clear H0.
     apply Forall_set => //=.
     eapply store_mem_agree; eauto.
-    * by destruct v => //=.
+    * by destruct t.
     * by move/ltP in H3.
   - (* another update memory : store some *)
     apply et_to_bet in HType; auto_basic. simpl in HType.
@@ -1665,11 +1649,7 @@ Proof.
     apply composition_typing in HType.
     destruct HType as [ts [t1s [t2s [t3s [H3 [H4 [H5 H6]]]]]]]. subst.
     invert_be_typing.
-    apply (Store_typing host_instance) in H6.
-    destruct H6 as [H7 [H8 H9]]. subst.
-    apply concat_cancel_last_n in H7 => //.
     remove_bools_options.
-    inversion H4. subst. clear H4.
     assert (store_extension s (upd_s_mem s (set_nth mem' (s_mems s) i mem'))) as Hext.
     { eapply store_extension_mem => //; first by rewrite H1.
       by eapply mem_extension_store; eauto.
@@ -1693,9 +1673,6 @@ Proof.
     apply composition_typing in HType.
     destruct HType as [ts [t1s [t2s [t3s [H3 [H4 [H5 H6]]]]]]]. subst.
     invert_be_typing.
-    apply (Grow_memory_typing host_instance) in H6.
-    destruct H6 as [ts' [H7 [H8 H9]]]. subst.
-    apply concat_cancel_last in H9 => //. destruct H9. subst.
     assert (store_extension s (upd_s_mem s (set_nth mem' (s_mems s) i mem'))) as Hext.
     { eapply store_extension_mem => //; first by rewrite H0.
       by eapply mem_extension_grow_memory; eauto.
@@ -1768,8 +1745,6 @@ Proof.
     apply composition_typing in HType.
     destruct HType as [ts' [t1s' [t2s' [t3s' [? [? [? Hbet]]]]]]]; subst.
     invert_be_typing.
-    apply (Set_local_typing host_instance) in Hbet as [t [Hnth [Hcat _]]].
-    apply concat_cancel_last in Hcat as [-> <-].
     replace (tc_local C) with ([::]: list value_type) in *; last by symmetry; eapply inst_t_context_local_empty; eauto.
     rewrite H1.
     rewrite set_nth_map => //.
@@ -1852,30 +1827,22 @@ Proof.
     by eapply t_simple_preservation; eauto.
   - (* Call *)
     convert_et_to_bet.
-    apply (Call_typing host_instance) in HType.
-    destruct HType as [ts [t1s' [t2s' [H1 [H2 [H3 H4]]]]]].
-    subst. simpl in H1. simpl in H2.
+    invert_be_typing.
     apply ety_weakening.
     eapply inst_typing_func in HIT1; eauto. destruct HIT1 as [cl HNthFunc].
     eapply ety_invoke; eauto.
-    assert ((Tf t1s' t2s') = cl_type cl) as HFType; first by eapply tc_func_reference1; eauto.
+    assert ((Tf ts1'_call ts2'_call) = cl_type cl) as HFType; first by eapply tc_func_reference1; eauto.
     rewrite HFType.
     by eapply store_typed_cl_typed; eauto.
   - (* Call_indirect *)
     convert_et_to_bet.
     replace [::BI_const (VAL_int32 c); BI_call_indirect i] with ([::BI_const (VAL_int32 c)] ++ [::BI_call_indirect i]) in HType => //=.
-    apply composition_typing in HType.
-    destruct HType as [ts' [t1s' [t2s' [t3s' [H1' [H2 [H3 H4]]]]]]].
-    subst.
     invert_be_typing.
-    apply (Call_indirect_typing host_instance) in H4.
-    destruct H4 as [tn [tm [ts [H5 [H6 [H7 [H8 H9]]]]]]].
-    rewrite catA in H8. apply concat_cancel_last in H8. destruct H8. subst. 
     simpl in *.
     repeat apply ety_weakening.
     eapply ety_invoke; eauto.
     unfold stypes in H1.
-    assert ((Tf tn tm) = cl_type cl) as HFType; first by eapply tc_func_reference2; eauto.
+    assert ((Tf ts_callindirect ts1'_callindirect) = cl_type cl) as HFType; first by eapply tc_func_reference2; eauto.
     rewrite HFType.
     by eapply store_typed_cl_typed; eauto.
   - (* Invoke native *)
@@ -1912,8 +1879,7 @@ Proof.
     apply Const_list_typing in H7.
     apply concat_cancel_last_n in H7; last by (repeat rewrite length_is_size in H2; rewrite size_map).
     remove_bools_options. subst.
-    (* We require more knowledge of the host at this point. *)
-    (* UPD: made it an axiom. *)
+    (* We require an axiomatic correctness assumption about the host. *)
     assert (result_types_agree t2s r).
     {
       destruct host_instance. apply host_application_respect in H5 => //.
@@ -1926,82 +1892,56 @@ Proof.
     by apply result_e_type.
   - (* Get_local *)
     convert_et_to_bet.
-    apply (Get_local_typing host_instance) in HType.
-    destruct HType as [t [H1 [H2 H3]]]. subst.
+    invert_be_typing.
     apply ety_a'; auto_basic => //=.
     assert (HCEmpty: tc_local C = [::]); first by eapply inst_t_context_local_empty; eauto.
-    rewrite HCEmpty in H1. rewrite HCEmpty in H3. rewrite HCEmpty.
-    simpl in H1. simpl in H3. simpl.
-    apply nth_error_map in H1. destruct H1 as [v' [HNth Hvt]]. subst.
+    rewrite -> HCEmpty in *.
+    simpl in *.
+    apply nth_error_map in H1_getlocal as [v' [HNth Hvt]]. subst.
     apply bet_weakening_empty_1.
     rewrite H in HNth. inversion HNth; subst.
     by apply bet_const.
   - (* Set_local *)
     convert_et_to_bet.
     replace [::BI_const v; BI_set_local i] with ([::BI_const v] ++ [::BI_set_local i]) in HType => //=.
-    apply composition_typing in HType.
-    destruct HType as [ts' [t1s' [t2s' [t3s' [H7 [H8 [H9 H10]]]]]]].
     invert_be_typing.
-    apply (Set_local_typing host_instance) in H10.
-    destruct H10 as [t [H4 [H5 H6]]]. subst.
     apply ety_a'; auto_basic => //=.
     assert (HCEmpty: tc_local C = [::]); first by eapply inst_t_context_local_empty; eauto.
-    rewrite HCEmpty in H6. rewrite HCEmpty in H4. rewrite HCEmpty.
-    simpl in H6. simpl in H5. simpl in H4. simpl.
-    apply concat_cancel_last in H5. destruct H5. subst.
+    rewrite -> HCEmpty in *. simpl in *.
     apply bet_weakening_empty_both.
     by apply bet_empty.
   - (* Get_global *)
     convert_et_to_bet.
-    apply (Get_global_typing host_instance) in HType.
-    destruct HType as [t [H4 [H5 H6]]]. subst.
+    invert_be_typing.
     apply ety_a'; auto_basic => //=.
     assert (tc_local C = [::]); first by eapply inst_t_context_local_empty; eauto.
-    rewrite H0 in H6. rewrite H0 in H4. rewrite H0.
-    simpl in H6. simpl in H4. simpl.
-    assert (typeof v = t); first by eapply global_type_reference; eauto.
-    rewrite -H1.
+    rewrite -> H0 in *; simpl in *.
+    assert (typeof v = ts_getglobal); first by eapply global_type_reference; eauto.
     apply bet_weakening_empty_1.
+    subst.
     by apply bet_const.
   - (* Set_Global *)
     convert_et_to_bet.
     replace [::BI_const v; BI_set_global i] with ([::BI_const v] ++ [::BI_set_global i]) in HType => //=.
-    apply composition_typing in HType.
-    destruct HType as [ts' [t1s' [t2s' [t3s' [H7 [H8 [H9 H10]]]]]]].
     invert_be_typing.
-    apply (Set_global_typing host_instance) in H10.
-    destruct H10 as [g [t [H4 [H5 [H6 [H7 H8]]]]]]. subst.
     apply ety_a'; auto_basic => //=.
-    simpl in H8. simpl in H4. simpl.
-    apply concat_cancel_last in H7. destruct H7. subst.
     apply bet_weakening_empty_both.
     by apply bet_empty.
   - (* Load None *)
     convert_et_to_bet.
     replace [::BI_const (VAL_int32 k); BI_load t None a off] with ([::BI_const (VAL_int32 k)] ++ [::BI_load t None a off]) in HType => //=.
-    apply composition_typing in HType.
-    destruct HType as [ts' [t1s' [t2s' [t3s' [H7 [H8 [H9 H10]]]]]]].
     invert_be_typing.
-    apply (Load_typing host_instance) in H10.
-    destruct H10 as [ts  [H11 [H12 [H13 H14]]]].
-    apply concat_cancel_last in H11. destruct H11. subst.
     eapply t_const_ignores_context => //=.
     instantiate (2 := s).
     apply ety_a'; auto_basic.
     simpl.
     assert (be_typing C [::BI_const (wasm_deserialise bs t)] (Tf [::] [:: typeof (wasm_deserialise bs t)])); first by apply bet_const.
-    rewrite catA.
-    apply bet_weakening_empty_1.
+    rewrite catA. apply bet_weakening_empty_1.
     rewrite typeof_deserialise in H2. by apply H2.
   - (* Load Some *)
     convert_et_to_bet.
     replace [::BI_const (VAL_int32 k); BI_load t (Some (tp, sx)) a off] with ([::BI_const (VAL_int32 k)] ++ [::BI_load t (Some (tp, sx)) a off]) in HType => //=.
-    apply composition_typing in HType.
-    destruct HType as [ts' [t1s' [t2s' [t3s' [H7 [H8 [H9 H10]]]]]]].
     invert_be_typing.
-    apply (Load_typing host_instance) in H10.
-    destruct H10 as [ts [H11 [H12 [H13 H14]]]].
-    apply concat_cancel_last in H11. destruct H11. subst.
     eapply t_const_ignores_context => //=.
     instantiate (2 := s).
     apply ety_a'; auto_basic.
@@ -2011,15 +1951,10 @@ Proof.
     rewrite typeof_deserialise in H2. by apply H2.
   - (* Store None *)
     + convert_et_to_bet.
-      simpl in HType.
       replace [::BI_const (VAL_int32 k); BI_const v; BI_store t None a off] with ([::BI_const (VAL_int32 k); BI_const v] ++ [::BI_store t None a off]) in HType => //=.
-      apply composition_typing in HType.
-      destruct HType as [ts' [t1s' [t2s' [t3s' [H7 [H8 [H9 H10]]]]]]].
       invert_be_typing.
-      apply (Store_typing host_instance) in H10.
-      destruct H10 as [H11 [H12 H13]].
-      apply concat_cancel_last_n in H11 => //.
-      move/andP in H11. destruct H11. move/eqP in H3. subst.
+      apply concat_cancel_last_n in H1_store => //.
+      remove_bools_options; subst.
       apply ety_a'; auto_basic => //=.
       apply bet_weakening_empty_both.
       by apply bet_empty.
@@ -2027,33 +1962,22 @@ Proof.
     + convert_et_to_bet.
       simpl in HType.
       replace [::BI_const (VAL_int32 k); BI_const v; BI_store t (Some tp) a off] with ([::BI_const (VAL_int32 k); BI_const v] ++ [::BI_store t (Some tp) a off]) in HType => //=.
-      apply composition_typing in HType.
-      destruct HType as [ts' [t1s' [t2s' [t3s' [H7 [H8 [H9 H10]]]]]]].
       invert_be_typing.
-      apply (Store_typing host_instance) in H10.
-      destruct H10 as [H11 [H12 H13]].
-      apply concat_cancel_last_n in H11 => //.
-      move/andP in H11. destruct H11. move/eqP in H3. subst.
+      apply concat_cancel_last_n in H1_store => //.
+      remove_bools_options; subst.
       apply ety_a'; auto_basic => //.
       apply bet_weakening_empty_both.
       by apply bet_empty.
   - (* Current_memory *)
     convert_et_to_bet.
-    apply (Current_memory_typing host_instance) in HType.
-    destruct HType as [H5 H6]. subst.
-    simpl.
+    invert_be_typing.
     apply ety_a'; auto_basic.
     apply bet_weakening_empty_1.
     by apply bet_const.
   - (* Grow_memory success *)
     convert_et_to_bet.
     replace [::BI_const (VAL_int32 c); BI_grow_memory] with ([::BI_const (VAL_int32 c)] ++ [::BI_grow_memory]) in HType => //.
-    apply composition_typing in HType.
-    destruct HType as [ts' [t1s' [t2s' [t3s' [H7 [H8 [H9 H10]]]]]]].
-    invert_be_typing.
-    apply (Grow_memory_typing host_instance) in H10.
-    destruct H10 as [ts [H11 [H12 H13]]]. subst.
-    simpl.
+    invert_be_typing => /=.
     apply ety_a'; auto_basic.
     rewrite catA.
     apply bet_weakening_empty_1.
@@ -2061,18 +1985,11 @@ Proof.
   - (* Grow_memory fail *)
     convert_et_to_bet.
     replace [::BI_const (VAL_int32 c); BI_grow_memory] with ([::BI_const (VAL_int32 c)] ++ [::BI_grow_memory]) in HType => //.
-    apply composition_typing in HType.
-    destruct HType as [ts' [t1s' [t2s' [t3s' [H7 [H8 [H9 H10]]]]]]].
-    invert_be_typing.
-    apply (Grow_memory_typing host_instance) in H10.
-    destruct H10 as [ts [H11 [H12 H13]]]. subst.
-    simpl.
+    invert_be_typing => /=.
     apply ety_a'; auto_basic.
     rewrite catA.
     apply bet_weakening_empty_1.
     by apply bet_const.
-  (* From the structure, it seems that some form of induction is required to prove these
-   2 cases. *)
   - (* r_label *)
     generalize dependent lh. generalize dependent les. generalize dependent les'.
     generalize dependent ty. generalize dependent tx. generalize dependent lab.

--- a/theories/typing_inversion.v
+++ b/theories/typing_inversion.v
@@ -15,18 +15,23 @@ Proof.
   by [].
 Qed.
 
+Ltac resolve_compose Hcat Hempty IH :=
+  apply extract_list1 in Hcat; destruct Hcat; subst;
+  apply empty_typing in Hempty; subst; try by eapply IH.
+
+Ltac resolve_weaken :=
+  repeat eexists; repeat split; eauto => /=; subst; repeat rewrite -catA => //.
+
 Lemma BI_const_typing: forall C econst t1s t2s,
     be_typing C [::BI_const econst] (Tf t1s t2s) ->
     t2s = t1s ++ [::typeof econst].
 Proof.
   move => C econst t1s t2s HType.
   gen_ind_subst HType => //.
-  - apply extract_list1 in H1; inversion H1; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
-  - rewrite - catA. f_equal.
-    + intros. by subst.
-    + by eapply IHHType.
+  - by resolve_compose Econs HType1 IHHType2.
+  - rewrite - catA -cat_app.
+    f_equal.
+    by eapply IHHType.
 Qed.
 
 Lemma BI_const2_typing: forall C econst1 econst2 t1s t2s,
@@ -39,9 +44,9 @@ Proof.
     apply BI_const_typing in HType1; subst.
     apply BI_const_typing in HType2; subst.
     by rewrite -catA.
-  - rewrite - catA. f_equal.
-    + intros. by subst.
-    + by eapply IHHType.
+  - rewrite - catA -cat_app.
+    f_equal.
+    by eapply IHHType.
 Qed.
 
 Lemma BI_const3_typing: forall C econst1 econst2 econst3 t1s t2s,
@@ -54,16 +59,15 @@ Proof.
     apply BI_const2_typing in HType1; subst.
     apply BI_const_typing in HType2; subst.
     by rewrite -catA.
-  - rewrite - catA. f_equal.
-    + intros. by subst.
-    + by eapply IHHType.
+  - rewrite - catA -cat_app.
+    f_equal.
+    by eapply IHHType.
 Qed.
 
 Lemma Const_list_typing_empty: forall C vs,
     be_typing C (to_b_list (v_to_e_list vs)) (Tf [::] (vs_to_vts vs)).
 Proof.
-  move => C vs.
-  generalize dependent vs.
+  move => C.
   induction vs => //=.
   - by apply bet_empty.
   - rewrite - cat1s.
@@ -78,16 +82,11 @@ Lemma Unop_typing: forall C t op t1s t2s,
 Proof.
   move => C t op t1s t2s HType.
   gen_ind_subst HType.
-  - split => //=. by exists [::].
-  - apply extract_list1 in H1; destruct H1; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
-  - edestruct IHHType => //=; subst.
-    split => //=.
-    destruct H0 as [ts' H0].
-    exists (ts ++ ts').
-    rewrite - catA.
-    by rewrite H0.
+  - by split => //=; exists nil.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [?[??]] => //=; subst.
+    split => //.
+    by eexists; rewrite -cat_app catA.
 Qed.
 
 Lemma Binop_typing: forall C t op t1s t2s,
@@ -97,17 +96,11 @@ Proof.
   move => C t op t1s t2s HType.
   gen_ind_subst HType.
   - split => //=. by exists [::].
-  - apply extract_list1 in H1; destruct H1; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
-  - edestruct IHHType => //=; subst.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [?[??]] => //=; subst.
+    repeat rewrite -cat_app; repeat rewrite catA.
     split => //=.
-    + destruct H0 as [ts' H0].
-      by rewrite - catA.
-    + destruct H0 as [ts' H0].
-      exists (ts ++ ts').
-      subst.
-      by rewrite - catA.
+    by eexists.
 Qed.
 
 Lemma Testop_typing: forall C t op t1s t2s,
@@ -117,13 +110,10 @@ Proof.
   move => C t op t1s t2s HType.
   gen_ind_subst HType.
   - by exists [::].
-  - apply extract_list1 in H1; destruct H1; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
-  - edestruct IHHType => //=; subst.
-    destruct H as [ts' H]. subst.
-    exists (ts ++ x).
-    by repeat rewrite - catA.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [?[??]] => //=; subst.
+    repeat rewrite -cat_app; repeat rewrite catA.
+    by eexists.
 Qed.
 
 Lemma Testop_typing_is_int_t: forall C t op t1s t2s,
@@ -131,15 +121,9 @@ Lemma Testop_typing_is_int_t: forall C t op t1s t2s,
     is_int_t t.
 Proof.
   move => C t op t1s t2s HType.
-  destruct t => //.
-  - gen_ind_subst HType => //.
-    * eapply IHHType2 => //.
-      by apply extract_list1 in Econs as [??]; subst e.
-    * eapply IHHType => //.
-  - gen_ind_subst HType => //.
-    * eapply IHHType2 => //.
-      by apply extract_list1 in Econs as [??]; subst e.
-    * eapply IHHType => //.
+  gen_ind_subst HType => //=.
+  - by resolve_compose Econs HType1 IHHType2.
+  - by eapply IHHType.
 Qed.
 
 Lemma Relop_typing: forall C t op t1s t2s,
@@ -149,13 +133,10 @@ Proof.
   move => C t op t1s t2s HType.
   gen_ind_subst HType.
   - by exists [::].
-  - apply extract_list1 in H1; destruct H1; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
-  - edestruct IHHType => //=; subst.
-    destruct H as [ts' H]. subst.
-    exists (ts ++ x).
-    by repeat rewrite - catA.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [?[??]] => //=; subst.
+    repeat rewrite -cat_app; repeat rewrite catA.
+    by eexists.
 Qed.
 
 Lemma Cvtop_typing: forall C t1 t2 op sx t1s t2s,
@@ -163,16 +144,11 @@ Lemma Cvtop_typing: forall C t1 t2 op sx t1s t2s,
     exists ts, t1s = ts ++ [::t1] /\ t2s = ts ++ [::t2].
 Proof.
   move => C t1 t2 op sx t1s t2s HType.
-  gen_ind_subst HType.
-  - by exists [::].
-  - by exists [::].
-  - apply extract_list1 in H1; destruct H1; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
-  - edestruct IHHType => //=; subst.
-    destruct H as [ts' H]. subst.
-    exists (ts ++ x).
-    by repeat rewrite - catA.
+  gen_ind_subst HType; try by exists nil.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [?[??]] => //=; subst.
+    repeat rewrite -cat_app; repeat rewrite catA.
+    by eexists.
 Qed.
 
 Lemma Cvtop_reinterpret_typing: forall C t1 t2 sx t1s t2s,
@@ -181,8 +157,7 @@ Lemma Cvtop_reinterpret_typing: forall C t1 t2 sx t1s t2s,
 Proof.
   move => C t1 t2 sx t1s t2s HType.
   gen_ind_subst HType => //.
-  - apply extract_list1 in H1; destruct H1; subst.
-    by eapply IHHType2.
+  - by resolve_compose Econs HType1 IHHType2.
   - by edestruct IHHType.
 Qed.
 
@@ -192,9 +167,7 @@ Lemma Nop_typing: forall C t1s t2s,
 Proof.
   move => C t1s t2s HType.
   gen_ind_subst HType => //.
-  - apply extract_list1 in Econs; destruct Econs; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
+  - by resolve_compose Econs HType1 IHHType2.
   - f_equal. by eapply IHHType.
 Qed.
 
@@ -205,11 +178,9 @@ Proof.
   move => C t1s t2s HType.
   gen_ind_subst HType => //=.
   - by eauto.
-  - apply extract_list1 in Econs; destruct Econs; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
+  - by resolve_compose Econs HType1 IHHType2.
   - edestruct IHHType => //=; subst.
-    exists x. repeat rewrite -catA. by f_equal.
+    by resolve_weaken.
 Qed.
 
 Lemma Select_typing: forall C t1s t2s,
@@ -219,12 +190,10 @@ Proof.
   move => C t1s t2s HType.
   gen_ind_subst HType => //.
   - by exists [::], t.
-  - apply extract_list1 in Econs; destruct Econs; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
-  - edestruct IHHType => //=; subst.
-    edestruct H as [x2 [H3 H4]]; subst.
-    exists (ts ++ x), x2. by split; repeat rewrite -catA.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [? [?[??]]] => //=; subst.
+    repeat rewrite -cat_app; repeat rewrite catA.
+    by repeat eexists.
 Qed.
 
 Lemma If_typing: forall C t1s t2s e1s e2s ts ts',
@@ -234,16 +203,12 @@ Lemma If_typing: forall C t1s t2s e1s e2s ts ts',
                 be_typing (upd_label C ([:: t2s] ++ tc_label C)) e2s (Tf t1s t2s).
 Proof.
   move => C t1s t2s e1s e2s ts ts' HType.
-  gen_ind_subst HType.
+  gen_ind_subst HType => //=.
   - by exists [::].
-  - apply extract_list1 in H1; destruct H1; subst.
-    apply empty_typing in HType1. subst.
-    by eapply IHHType2.
-  - edestruct IHHType => //=; subst.
-    destruct H as [H1 [H2 [H3 H4]]]. subst.
-    exists (ts ++ x).
-    repeat rewrite -catA.
-    repeat split => //=.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [? [? [? ?]]]] => //=; subst.
+    exists (ts ++ ts0).
+    by resolve_weaken.
 Qed.
 
 Lemma Br_if_typing: forall C ts1 ts2 i,
@@ -251,19 +216,12 @@ Lemma Br_if_typing: forall C ts1 ts2 i,
     exists ts ts', ts2 = ts ++ ts' /\ ts1 = ts2 ++ [::T_i32] /\ i < length (tc_label C) /\ plop2 C i ts'.
 Proof.
   move => C ts1 ts2 i HType.
-  gen_ind_subst HType.
-  - unfold plop2 in H0.
-    by exists [::], ts2.
-  - apply extract_list1 in H1; destruct H1; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
-  - rewrite -catA. f_equal => //=.
-    edestruct IHHType => //=.
-    destruct H as [ts' [H1 [H2 [H3 H4]]]].
-    exists (ts ++ x), ts'. subst.
-    split.
-    + repeat rewrite -catA. by f_equal.
-    + split => //=.
+  gen_ind_subst HType => //=.
+  - by exists nil; eexists.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [? [? [? [? ?]]]]] => //=; subst.
+    exists (ts ++ ts0).
+    by resolve_weaken.
 Qed.
 
 Lemma Br_table_typing: forall C ts1 ts2 ids i0,
@@ -274,14 +232,10 @@ Proof.
   move => C ts1 ts2 ids i0 HType.
   gen_ind_subst HType.
   - by exists t1s, ts.
-  - apply extract_list1 in H1; destruct H1; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2.
-  - edestruct IHHType => //=.
-    destruct H as [ts' [H1 H2]].
-    exists (ts ++ x), ts'. subst.
-    split => //=.
-    + repeat rewrite -catA. by f_equal => //=.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [ts' [??]]] => //=; subst.
+    exists (ts ++ ts0), ts'.
+    by resolve_weaken.
 Qed.
 
 Lemma Tee_local_typing: forall C i ts1 ts2,
@@ -292,14 +246,209 @@ Proof.
   move => C i ts1 ts2 HType.
   gen_ind_subst HType.
   - by exists [::], t.
-  - apply extract_list1 in H1; destruct H1; subst.
-    apply empty_typing in HType1; subst.
-    by eapply IHHType2 => //=.
-  - edestruct IHHType => //=.
-    destruct H as [t [H1 [H2 [H3 H4]]]]. subst.
-    exists (ts ++ x), t. subst.
-    repeat (try split => //=).
-    by rewrite -catA.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [t [? [? [??]]]]] => //=.
+    exists (ts ++ ts0), t.
+    by resolve_weaken.
+Qed.
+
+Lemma Get_local_typing: forall C i t1s t2s,
+    be_typing C [::BI_get_local i] (Tf t1s t2s) ->
+    exists t, List.nth_error (tc_local C) i = Some t /\
+    t2s = t1s ++ [::t] /\
+    i < length (tc_local C).
+Proof.
+  move => ???? HType.
+  gen_ind_subst HType => //=.
+  - by eexists; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [?[?[??]]]; eauto => //=.
+    by resolve_weaken.
+Qed.
+
+Lemma Set_local_typing: forall C i t1s t2s,
+    be_typing C [::BI_set_local i] (Tf t1s t2s) ->
+    exists t, List.nth_error (tc_local C) i = Some t /\
+    t1s = t2s ++ [::t] /\
+    i < length (tc_local C).
+Proof.
+  move => ???? HType.
+  gen_ind_subst HType => //=.
+  - by eexists; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [?[?[??]]]; eauto => //=.
+    by resolve_weaken.
+Qed.
+  
+Lemma Get_global_typing: forall C i t1s t2s,
+    be_typing C [::BI_get_global i] (Tf t1s t2s) ->
+    exists t, option_map tg_t (List.nth_error (tc_global C) i) = Some t /\
+    t2s = t1s ++ [::t] /\
+    i < length (tc_global C).
+Proof.
+  move => ???? HType.
+  gen_ind_subst HType => //=.
+  - by eexists; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [?[?[??]]]; eauto => //=.
+    by resolve_weaken.
+Qed.
+
+Lemma Set_global_typing: forall C i t1s t2s,
+    be_typing C [::BI_set_global i] (Tf t1s t2s) ->
+    exists g t, List.nth_error (tc_global C) i = Some g /\
+    tg_t g = t /\
+    is_mut g /\
+    t1s = t2s ++ [::t] /\
+    i < length (tc_global C).
+Proof.
+  intros ???? HType.
+  gen_ind_subst HType => //=.
+  - by do 2 eexists; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [? [? [? [? [? [? ?]]]]]]; subst=> //=.
+    by resolve_weaken.
+Qed.
+
+Lemma Load_typing: forall C t a off tp_sx t1s t2s,
+    be_typing C [::BI_load t tp_sx a off] (Tf t1s t2s) ->
+    exists ts, t1s = ts ++ [::T_i32] /\ t2s = ts ++ [::t] /\
+                    tc_memory C <> nil /\
+                    load_store_t_bounds a (option_projl tp_sx) t.
+Proof.
+  intros ??????? HType.
+  gen_ind_subst HType => //=.
+  - by exists nil; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [? [? [? ?]]]]; subst => //=.
+    exists (ts ++ ts0).
+    by resolve_weaken.
+Qed.
+
+Lemma Store_typing: forall C t a off tp t1s t2s,
+    be_typing C [::BI_store t tp a off] (Tf t1s t2s) ->
+    t1s = t2s ++ [::T_i32; t] /\
+    tc_memory C <> nil /\
+    load_store_t_bounds a tp t.
+Proof.
+  intros ??????? HType.
+  gen_ind_subst HType => //=.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [? [??]]; subst=> //=.
+    by resolve_weaken.
+Qed.
+
+Lemma Current_memory_typing: forall C t1s t2s,
+    be_typing C [::BI_current_memory] (Tf t1s t2s) ->
+    tc_memory C <> nil /\ t2s = t1s ++ [::T_i32].
+Proof.
+  intros ??? HType.
+  gen_ind_subst HType => //=.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType; subst=> //=.
+    by resolve_weaken.
+Qed.
+
+Lemma Grow_memory_typing: forall C t1s t2s,
+    be_typing C [::BI_grow_memory] (Tf t1s t2s) ->
+    exists ts, tc_memory C <> nil /\ t2s = t1s /\ t1s = ts ++ [::T_i32].
+Proof.
+  intros ??? HType.
+  gen_ind_subst HType => //=.
+  - by exists nil; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [? [? ?]]]; subst => //=.
+    exists (ts ++ ts0).
+    by resolve_weaken.
+Qed.
+
+Lemma Block_typing: forall C t1s t2s es tn tm,
+    be_typing C [::BI_block (Tf t1s t2s) es] (Tf tn tm) ->
+    exists ts, tn = ts ++ t1s /\ tm = ts ++ t2s /\
+               be_typing (upd_label C ([::t2s] ++ (tc_label C))) es (Tf t1s t2s).
+Proof.
+  intros ?????? HType.
+  gen_ind_subst HType => //=.
+  - by exists nil; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [? [? ?]]]; subst => //=.
+    exists (ts ++ ts0).
+    by resolve_weaken.
+Qed.
+
+Lemma Loop_typing: forall C t1s t2s es tn tm,
+    be_typing C [::BI_loop (Tf t1s t2s) es] (Tf tn tm) ->
+    exists ts, tn = ts ++ t1s /\ tm = ts ++ t2s /\
+               be_typing (upd_label C ([::t1s] ++ (tc_label C))) es (Tf t1s t2s).
+Proof.
+  intros ?????? HType.
+  gen_ind_subst HType => //=.
+  - by exists nil; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [? [? ?]]]; subst => //=.
+    exists (ts ++ ts0).
+    by resolve_weaken.
+Qed.
+
+Lemma Break_typing: forall n C t1s t2s,
+    be_typing C [::BI_br n] (Tf t1s t2s) ->
+    exists ts ts0, n < size (tc_label C) /\
+               plop2 C n ts /\
+               t1s = ts0 ++ ts.
+Proof.
+  intros ???? HType.
+  gen_ind_subst HType => //=.
+  - by do 2 eexists; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [ts' [? [??]]]]; subst => //=.
+    exists ts0, (ts ++ ts').
+    by resolve_weaken.
+Qed.
+
+Lemma Return_typing: forall C t1s t2s,
+    be_typing C [::BI_return] (Tf t1s t2s) ->
+    exists ts ts', t1s = ts' ++ ts /\
+                   tc_return C = Some ts.
+Proof.
+  intros ??? HType.
+  gen_ind_subst HType => //=.
+  - by do 2 eexists; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [ts' [? ?]]]; subst => //=.
+    exists ts0, (ts ++ ts').
+    by resolve_weaken.
+Qed.
+
+Lemma Call_typing: forall j C t1s t2s,
+    be_typing C [::BI_call j] (Tf t1s t2s) ->
+    exists ts t1s' t2s', j < length (tc_func_t C) /\
+    List.nth_error (tc_func_t C) j = Some (Tf t1s' t2s') /\
+                         t1s = ts ++ t1s' /\
+                         t2s = ts ++ t2s'.
+Proof.
+  intros ???? HType.
+  gen_ind_subst HType => //=.
+  - by exists nil; do 2 eexists; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [ts1' [ts2' [?[?[??]]]]]]; subst => //=.
+    exists (ts ++ ts0), ts1', ts2'.
+    by resolve_weaken.
+Qed.
+
+Lemma Call_indirect_typing: forall i C t1s t2s,
+    be_typing C [::BI_call_indirect i] (Tf t1s t2s) ->
+    exists tn tm ts, tc_table C <> nil /\
+    i < length (tc_types_t C) /\
+    List.nth_error (tc_types_t C) i = Some (Tf tn tm) /\
+    t1s = ts ++ tn ++ [::T_i32] /\ t2s = ts ++ tm.
+Proof.
+  intros ???? HType.
+  gen_ind_subst HType => //=.
+  - by do 2 eexists; exists nil; eauto.
+  - by resolve_compose Econs HType1 IHHType2.
+  - edestruct IHHType as [ts0 [ts1' [ts2' [?[?[?[??]]]]]]]; subst => //=.
+    exists ts0, ts1', (ts ++ ts2').
+    by resolve_weaken.
 Qed.
 
 Lemma Const_list_typing: forall C vs t1s t2s,
@@ -319,25 +468,6 @@ Proof.
     subst.
     by repeat rewrite catA.
 Qed.
-
-(* We need this version for dealing with the version of predicate with host. *)
-Ltac basic_inversion' :=
-   repeat lazymatch goal with
-         | H: True |- _ =>
-           clear H
-         | H: es_is_basic (_ ++ _) |- _ =>
-           let Ha := fresh H in
-           let Hb := fresh H in
-           apply basic_concat in H; destruct H as [Ha Hb]
-         | H: es_is_basic [::] |- _ =>
-           clear H
-         | H: es_is_basic [::_] |- _ =>
-           let H1 := fresh H in
-           let H2 := fresh H in
-           try by (unfold es_is_basic in H; destruct H as [H1 H2]; inversion H1)
-         | H: e_is_basic _ |- _ =>
-           inversion H; try by []
-         end.
 
 (* TODO use this in itp completeness lemmas? *)
 Ltac invert_be_typing:=
@@ -359,76 +489,169 @@ Ltac invert_be_typing:=
   | H: be_typing _ [:: BI_const _; BI_const _; BI_const _] _ |- _ =>
     apply BI_const3_typing in H; subst
   | H: be_typing _ [::BI_unop _ _] _ |- _ =>
-    let ts := fresh "ts" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
+    let ts := fresh "ts_unop" in
+    let H1 := fresh "H1_unop" in
+    let H2 := fresh "H2_unop" in
     apply Unop_typing in H; destruct H as [H1 [ts H2]]; subst
   | H: be_typing _ [::BI_binop _ _] _ |- _ =>
-    let ts := fresh "ts" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
+    let ts := fresh "ts_binop" in
+    let H1 := fresh "H1_binop" in
+    let H2 := fresh "H2_binop" in
     apply Binop_typing in H; destruct H as [H1 [ts H2]]; subst
   | H: be_typing _ [::BI_testop _ _] _ |- _ =>
-    let ts := fresh "ts" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
+    let ts := fresh "ts_testop" in
+    let H1 := fresh "H1_testop" in
+    let H2 := fresh "H2_testop" in
     apply Testop_typing in H; destruct H as [ts [H1 H2]]; subst
   | H: be_typing _ [::BI_relop _ _] _ |- _ =>
-    let ts := fresh "ts" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
+    let ts := fresh "ts_relop" in
+    let H1 := fresh "H1_relop" in
+    let H2 := fresh "H2_relop" in
     apply Relop_typing in H; destruct H as [ts [H1 H2]]; subst
   | H: be_typing _ [::BI_cvtop _ _ _ _] _ |- _ =>
-    let ts := fresh "ts" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
+    let ts := fresh "ts_cvtop" in
+    let H1 := fresh "H1_cvtop" in
+    let H2 := fresh "H2_cvtop" in
     apply Cvtop_typing in H; destruct H as [ts [H1 H2]]; subst
   | H: be_typing _ [::BI_drop] _ |- _ =>
     apply Drop_typing in H; destruct H; subst
   | H: be_typing _ [::BI_select] _ |- _ =>
-    let ts := fresh "ts" in
-    let t := fresh "t" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
+    let ts := fresh "ts_select" in
+    let t := fresh "t_select" in
+    let H1 := fresh "H1_select" in
+    let H2 := fresh "H2_select" in
     apply Select_typing in H; destruct H as [ts [t [H1 H2]]]; subst
   | H: be_typing _ [::BI_if _ _ _] _ |- _ =>
-    let ts := fresh "ts" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
-    let H3 := fresh "H3" in
-    let H4 := fresh "H4" in
+    let ts := fresh "ts_if" in
+    let H1 := fresh "H1_if" in
+    let H2 := fresh "H2_if" in
+    let H3 := fresh "H3_if" in
+    let H4 := fresh "H4_if" in
     apply If_typing in H; destruct H as [ts [H1 [H2 [H3 H4]]]]; subst
   | H: be_typing _ [::BI_br_if _] _ |- _ =>
-    let ts := fresh "ts" in
-    let ts' := fresh "ts'" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
-    let H3 := fresh "H3" in
-    let H4 := fresh "H4" in
+    let ts := fresh "ts_brif" in
+    let ts' := fresh "ts'_brif" in
+    let H1 := fresh "H1_brif" in
+    let H2 := fresh "H2_brif" in
+    let H3 := fresh "H3_brif" in
+    let H4 := fresh "H4_brif" in
     apply Br_if_typing in H; destruct H as [ts [ts' [H1 [H2 [H3 H4]]]]]; subst
   | H: be_typing _ [::BI_br_table _ _] _ |- _ =>
-    let ts := fresh "ts" in
-    let ts' := fresh "ts'" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
+    let ts := fresh "ts_brtable" in
+    let ts' := fresh "ts'_brtable" in
+    let H1 := fresh "H1_brtable" in
+    let H2 := fresh "H2_brtable" in
     apply Br_table_typing in H; destruct H as [ts [ts' [H1 H2]]]; subst
   | H: be_typing _ [::BI_tee_local _] _ |- _ =>
-    let ts := fresh "ts" in
-    let t := fresh "t" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
-    let H3 := fresh "H3" in
-    let H4 := fresh "H4" in
+    let ts := fresh "ts_teelocal" in
+    let t := fresh "t_teelocal" in
+    let H1 := fresh "H1_teelocal" in
+    let H2 := fresh "H2_teelocal" in
+    let H3 := fresh "H3_teelocal" in
+    let H4 := fresh "H4_teelocal" in
     apply Tee_local_typing in H; destruct H as [ts [t [H1 [H2 [H3 H4]]]]]; subst
+  | H: be_typing _ [::BI_get_local _] _ |- _ =>
+    let ts := fresh "ts_getlocal" in
+    let H1 := fresh "H1_getlocal" in
+    let H2 := fresh "H2_getlocal" in
+    let H3 := fresh "H3_getlocal" in
+    apply Get_local_typing in H; destruct H as [ts [H1 [H2 H3]]]; subst
+  | H: be_typing _ [::BI_set_local _] _ |- _ =>
+    let ts := fresh "ts_setlocal" in
+    let H1 := fresh "H1_setlocal" in
+    let H2 := fresh "H2_setlocal" in
+    let H3 := fresh "H3_setlocal" in
+    apply Set_local_typing in H; destruct H as [ts [H1 [H2 H3]]]; subst
+  | H: be_typing _ [::BI_get_global _] _ |- _ =>
+    let ts := fresh "ts_getglobal" in
+    let H1 := fresh "H1_getglobal" in
+    let H2 := fresh "H2_getglobal" in
+    let H3 := fresh "H3_getglobal" in
+    apply Get_global_typing in H; destruct H as [ts [H1 [H2 H3]]]; subst
+  | H: be_typing _ [::BI_set_global _] _ |- _ =>
+    let g := fresh "g_setglobal" in
+    let t := fresh "t_setglobal" in
+    let H1 := fresh "H1_setglobal" in
+    let H2 := fresh "H2_setglobal" in
+    let H3 := fresh "H3_setglobal" in
+    let H4 := fresh "H4_setglobal" in
+    let H5 := fresh "H5_setglobal" in
+    apply Set_global_typing in H; destruct H as [g [t [H1 [H2 [H3 [H4 H5]]]]]]; subst
+  | H: be_typing _ [::BI_load _ _ _ _] _ |- _ =>
+    let ts := fresh "ts_load" in
+    let H1 := fresh "H1_load" in
+    let H2 := fresh "H2_load" in
+    let H3 := fresh "H3_load" in
+    let H4 := fresh "H4_load" in
+    apply Load_typing in H; destruct H as [ts [H1 [H2 [H3 H4]]]]; subst
+  | H: be_typing _ [::BI_store _ _ _ _] _ |- _ =>
+    let H1 := fresh "H1_store" in
+    let H2 := fresh "H2_store" in
+    let H3 := fresh "H3_store" in
+    apply Store_typing in H; destruct H as [H1 [H2 H3]]; subst
+  | H: be_typing _ [::BI_current_memory] _ |- _ =>
+    let H1 := fresh "H1_currentmemory" in
+    let H2 := fresh "H2_currentmemory" in
+    apply Current_memory_typing in H; destruct H as [H1 H2]; subst
+  | H: be_typing _ [::BI_grow_memory] _ |- _ =>
+    let ts := fresh "ts_growmemory" in
+    let H1 := fresh "H1_growmemory" in
+    let H2 := fresh "H2_growmemory" in
+    let H3 := fresh "H3_growmemory" in
+    apply Grow_memory_typing in H; destruct H as [ts [H1 [H2 H3]]]; subst
+  | H: be_typing _ [::BI_block _ _] _ |- _ =>
+    let ts := fresh "ts_block" in
+    let H1 := fresh "H1_block" in
+    let H2 := fresh "H2_block" in
+    let H3 := fresh "H3_block" in
+    apply Block_typing in H; destruct H as [ts [H1 [H2 H3]]]; subst
+  | H: be_typing _ [::BI_loop _ _] _ |- _ =>
+    let ts := fresh "ts_loop" in
+    let H1 := fresh "H1_loop" in
+    let H2 := fresh "H2_loop" in
+    let H3 := fresh "H3_loop" in
+    apply Loop_typing in H; destruct H as [ts [H1 [H2 H3]]]; subst
+  | H: be_typing _ [::BI_br _] _ |- _ =>
+    let ts := fresh "ts_br" in
+    let ts0 := fresh "ts0_br" in
+    let H1 := fresh "H1_br" in
+    let H2 := fresh "H2_br" in
+    let H3 := fresh "H3_br" in
+    apply Break_typing in H; destruct H as [ts [ts0 [H1 [H2 H3]]]]; subst
+  | H: be_typing _ [::BI_return] _ |- _ =>
+    let ts := fresh "ts_return" in
+    let ts0 := fresh "ts0_return" in
+    let H1 := fresh "H1_return" in
+    let H2 := fresh "H2_return" in
+    apply Return_typing in H; destruct H as [ts [ts0 [H1 H2]]]; subst
+  | H: be_typing _ [::BI_call _] _ |- _ =>
+    let ts := fresh "ts_call" in
+    let ts1' := fresh "ts1'_call" in
+    let ts2' := fresh "ts2'_call" in
+    let H1 := fresh "H1_call" in
+    let H2 := fresh "H2_call" in
+    let H3 := fresh "H3_call" in
+    let H4 := fresh "H4_call" in
+    apply Call_typing in H; destruct H as [ts [ts1' [ts2' [H1 [H2 [H3 H4]]]]]]; subst
+  | H: be_typing _ [::BI_call_indirect _] _ |- _ =>
+    let ts := fresh "ts_callindirect" in
+    let ts1' := fresh "ts1'_callindirect" in
+    let ts2' := fresh "ts2'_callindirect" in
+    let H1 := fresh "H1_callindirect" in
+    let H2 := fresh "H2_callindirect" in
+    let H3 := fresh "H3_callindirect" in
+    let H4 := fresh "H4_callindirect" in
+    let H5 := fresh "H5_callindirect" in
+    apply Call_indirect_typing in H; destruct H as [ts [ts1' [ts2' [H1 [H2 [H3 [H4 H5]]]]]]]; subst
   | H: be_typing _ (_ ++ _) _ |- _ =>
-    let ts1 := fresh "ts1" in
-    let ts2 := fresh "ts2" in
-    let ts3 := fresh "ts3" in
-    let ts4 := fresh "ts4" in
-    let H1 := fresh "H1" in
-    let H2 := fresh "H2" in
-    let H3 := fresh "H3" in
-    let H4 := fresh "H4" in
+    let ts1 := fresh "ts1_comp" in
+    let ts2 := fresh "ts2_comp" in
+    let ts3 := fresh "ts3_comp" in
+    let ts4 := fresh "ts4_comp" in
+    let H1 := fresh "H1_comp" in
+    let H2 := fresh "H2_comp" in
+    let H3 := fresh "H3_comp" in
+    let H4 := fresh "H4_comp" in
     apply composition_typing in H; destruct H as [ts1 [ts2 [ts3 [ts4 [H1 [H2 [H3 H4]]]]]]]
   | H: be_typing _ [::_;_] _ |- _ =>
     rewrite -cat1s in H
@@ -438,6 +661,10 @@ Ltac invert_be_typing:=
     rewrite -cat1s in H
   | H: _ ++ [::_] = _ ++ [::_] |- _ =>
     apply concat_cancel_last in H; destruct H; subst
+  | H: _ ++ [::_] = _ ++ _ ++ [::_] |- _ =>
+    rewrite catA in H; apply concat_cancel_last in H; destruct H; subst
+  | H: _ ++ _ ++ [::_] = _ ++ [::_] |- _ =>
+    rewrite catA in H; apply concat_cancel_last in H; destruct H; subst
   end.
 
 Ltac et_dependent_ind' H :=
@@ -569,138 +796,6 @@ Proof.
     inversion HNth; subst; clear HNth.
     inversion H0; subst.
     by exists [::].
-Qed.
-
-Lemma Get_local_typing: forall C i t1s t2s,
-    be_typing C [::BI_get_local i] (Tf t1s t2s) ->
-    exists t, List.nth_error (tc_local C) i = Some t /\
-    t2s = t1s ++ [::t] /\
-    i < length (tc_local C).
-Proof.
-  move => C i t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - by exists t.
-  - invert_be_typing.
-    by apply IHHType2.
-  - edestruct IHHType => //=.
-    destruct H as [H1 [H2 H3]]. subst.
-    exists x.
-    repeat split => //=.
-    by rewrite -catA.
-Qed.
-
-Lemma Set_local_typing: forall C i t1s t2s,
-    be_typing C [::BI_set_local i] (Tf t1s t2s) ->
-    exists t, List.nth_error (tc_local C) i = Some t /\
-    t1s = t2s ++ [::t] /\
-    i < length (tc_local C).
-Proof.
-  move => C i t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - by exists t.
-  - invert_be_typing.
-    by apply IHHType2.
-  - edestruct IHHType => //=.
-    destruct H as [H1 [H2 H3]]. subst.
-    exists x.
-    repeat split => //=.
-    by rewrite -catA.
-Qed.
-
-Lemma Get_global_typing: forall C i t1s t2s,
-    be_typing C [::BI_get_global i] (Tf t1s t2s) ->
-    exists t, option_map tg_t (List.nth_error (tc_global C) i) = Some t /\
-    t2s = t1s ++ [::t] /\
-    i < length (tc_global C).
-Proof.
-  move => C i t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - by exists t.
-  - invert_be_typing.
-    by apply IHHType2.
-  - edestruct IHHType => //=.
-    destruct H as [H1 [H2 H3]]. subst.
-    exists x.
-    repeat split => //=.
-    by rewrite -catA.
-Qed.
-
-Lemma Set_global_typing: forall C i t1s t2s,
-    be_typing C [::BI_set_global i] (Tf t1s t2s) ->
-    exists g t, List.nth_error (tc_global C) i = Some g /\
-    tg_t g = t /\
-    is_mut g /\
-    t1s = t2s ++ [::t] /\
-    i < length (tc_global C).
-Proof.
-  move => C i t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - by exists g, (tg_t g).
-  - invert_be_typing.
-    by apply IHHType2.
-  - edestruct IHHType => //=.
-    destruct H as [t [H1 [H2 [H3 [H4 H5]]]]]. subst.
-    exists x, (tg_t x).
-    repeat split => //=.
-    by rewrite -catA.
-Qed.
-
-Lemma Load_typing: forall C t a off tp_sx t1s t2s,
-    be_typing C [::BI_load t tp_sx a off] (Tf t1s t2s) ->
-    exists ts, t1s = ts ++ [::T_i32] /\ t2s = ts ++ [::t] /\
-                    tc_memory C <> nil /\
-                    load_store_t_bounds a (option_projl tp_sx) t.
-Proof.
-  move => C t a off tp_sx t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - by exists [::].
-  - invert_be_typing.
-    by eapply IHHType2.
-  - edestruct IHHType => //=.
-    destruct H as [H1 [H2 [H3 H4]]]. subst.
-    exists (ts ++ x).
-    by repeat rewrite -catA.
-Qed.
-
-Lemma Store_typing: forall C t a off tp t1s t2s,
-    be_typing C [::BI_store t tp a off] (Tf t1s t2s) ->
-    t1s = t2s ++ [::T_i32; t] /\
-    tc_memory C <> nil /\
-    load_store_t_bounds a tp t.
-Proof.
-  move => C t a off tp t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - invert_be_typing.
-    by eapply IHHType2.
-  - edestruct IHHType => //=. subst.
-    by repeat rewrite -catA.
-Qed.
-
-Lemma Current_memory_typing: forall C t1s t2s,
-    be_typing C [::BI_current_memory] (Tf t1s t2s) ->
-    tc_memory C <> nil /\ t2s = t1s ++ [::T_i32].
-Proof.
-  move => C t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - invert_be_typing.
-    by eapply IHHType2.
-  - edestruct IHHType => //=. subst.
-    by repeat rewrite -catA.
-Qed.
-
-Lemma Grow_memory_typing: forall C t1s t2s,
-    be_typing C [::BI_grow_memory] (Tf t1s t2s) ->
-    exists ts, tc_memory C <> nil /\ t2s = t1s /\ t1s = ts ++ [::T_i32].
-Proof.
-  move => C t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - by exists [::].
-  - invert_be_typing.
-    by eapply IHHType2.
-  - edestruct IHHType => //=.
-    destruct H as [H1 [H2 H3]]. subst.
-    exists (ts ++ x).
-    by repeat rewrite -catA.
 Qed.
 
 Lemma store_typed_cl_typed: forall s n f,
@@ -903,58 +998,6 @@ Ltac auto_basic :=
     by unfold e_is_basic; exists e
 end.
 
-Lemma Block_typing: forall C t1s t2s es tn tm,
-    be_typing C [::BI_block (Tf t1s t2s) es] (Tf tn tm) ->
-    exists ts, tn = ts ++ t1s /\ tm = ts ++ t2s /\
-               be_typing (upd_label C ([::t2s] ++ (tc_label C))) es (Tf t1s t2s).
-Proof.
-  move => C t1s t2s es tn tm HType.
-  dependent induction HType => //=.
-  - by exists [::].
-  - invert_be_typing.
-    by apply IHHType2 => //=.
-  - edestruct IHHType => //=.
-    destruct H as [H1 [H2 H3]]. subst.
-    exists (ts ++ x).
-    repeat rewrite -catA.
-    by repeat split => //=.
-Qed.
-
-Lemma Loop_typing: forall C t1s t2s es tn tm,
-    be_typing C [::BI_loop (Tf t1s t2s) es] (Tf tn tm) ->
-    exists ts, tn = ts ++ t1s /\ tm = ts ++ t2s /\
-               be_typing (upd_label C ([::t1s] ++ (tc_label C))) es (Tf t1s t2s).
-Proof.
-  move => C t1s t2s es tn tm HType.
-  dependent induction HType => //=.
-  - by exists [::].
-  - invert_be_typing.
-    by apply IHHType2 => //=.
-  - edestruct IHHType => //=.
-    destruct H as [H1 [H2 H3]]. subst.
-    exists (ts ++ x).
-    repeat rewrite -catA.
-    by repeat split => //=.
-Qed.
-
-Lemma Break_typing: forall n C t1s t2s,
-    be_typing C [::BI_br n] (Tf t1s t2s) ->
-    exists ts ts0, n < size (tc_label C) /\
-               plop2 C n ts /\
-               t1s = ts0 ++ ts.
-Proof.
-  move => n C t1s t2s HType.
-  dependent induction HType => //=.
-  - by exists ts, t1s0.
-  - invert_be_typing.
-    by eapply IHHType2 => //=.
-  - edestruct IHHType => //=.
-    destruct H as [ts0 [H1 [H2 H3]]]. subst.
-    exists x, (ts ++ ts0).
-    repeat split => //=.
-    by rewrite -catA.
-Qed.
-
 Lemma Label_typing: forall s C n es0 es ts1 ts2,
     e_typing s C [::AI_label n es0 es] (Tf ts1 ts2) ->
     exists ts ts2', ts2 = ts1 ++ ts2' /\
@@ -963,15 +1006,10 @@ Lemma Label_typing: forall s C n es0 es ts1 ts2,
                     length ts = n.
 Proof.
   move => s C n es0 es ts1 ts2 HType.
-  (* Without the powerful generalize_dependent tactic, we need to manually remember
-     the dependent terms. However, it's very easy to mess up the induction hypothesis
-     if variables are not correctly generalized.
-     Reading source: https://stackoverflow.com/questions/58349365/coq-how-to-correctly-remember-dependent-values-without-messing-up-the-inductio 
-   *)
   et_dependent_ind HType => //.
   - (* ety_a *)
     assert (es_is_basic (operations.to_e_list bes)); first by apply to_e_list_basic.
-    rewrite Hremes in H0. by basic_inversion'.
+    rewrite Hremes in H0. by basic_inversion.
   - (* ety_composition *)
     apply extract_list1 in Hremes. destruct Hremes. subst.
     apply et_to_bet in HType1 => //.
@@ -1080,7 +1118,7 @@ Proof.
   induction HType; subst => //.
   - (* ety_a *)
     assert (es_is_basic (operations.to_e_list bes)); first by apply to_e_list_basic.
-    rewrite Heqles in H0. by basic_inversion'.
+    rewrite Heqles in H0. by basic_inversion.
   - (* ety_composition *)
     apply extract_list1 in Heqles. destruct Heqles. subst.
     apply et_to_bet in HType1 => //.
@@ -1098,23 +1136,6 @@ Proof.
     inversion Heqles. subst.
     move => t2s t1s HTf. inversion HTf. subst.
     by exists t2s.
-Qed.
-
-Lemma Return_typing: forall C t1s t2s,
-    be_typing C [::BI_return] (Tf t1s t2s) ->
-    exists ts ts', t1s = ts' ++ ts /\
-                   tc_return C = Some ts.
-Proof.
-  move => C t1s t2s HType.
-  dependent induction HType => //=.
-  - by exists ts, t1s0.
-  - invert_be_typing.
-    by eapply IHHType2 => //=.
-  - edestruct IHHType => //=.
-    destruct H as [ts' [H1 H2]]. subst.
-    exists x, (ts ++ ts').
-    split => //=.
-    by rewrite -catA.
 Qed.
 
 Lemma Lfilled_return_typing: forall n lh vs LI ts s C lab t2s,
@@ -1215,44 +1236,6 @@ Proof.
   apply Const_list_typing in HET; subst => /=.
   apply ety_a'; first by apply const_list_is_basic; apply v_to_e_is_const_list.
   by apply Const_list_typing_empty.
-Qed.
-
-Lemma Call_typing: forall j C t1s t2s,
-    be_typing C [::BI_call j] (Tf t1s t2s) ->
-    exists ts t1s' t2s', j < length (tc_func_t C) /\
-    List.nth_error (tc_func_t C) j = Some (Tf t1s' t2s') /\
-                         t1s = ts ++ t1s' /\
-                         t2s = ts ++ t2s'.
-Proof.
-  move => j C t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - by exists [::], t1s, t2s.
-  - invert_be_typing.
-    by apply IHHType2 => //=.
-  - edestruct IHHType => //=.
-    destruct H as [t1s' [t2s' [H1 [H2 [H3 H4]]]]].
-    subst.
-    exists (ts ++ x), t1s', t2s'.
-    repeat rewrite -catA.
-    by repeat (split => //=).
-Qed.
-
-Lemma Call_indirect_typing: forall i C t1s t2s,
-    be_typing C [::BI_call_indirect i] (Tf t1s t2s) ->
-    exists tn tm ts, tc_table C <> nil /\
-    i < length (tc_types_t C) /\
-    List.nth_error (tc_types_t C) i = Some (Tf tn tm) /\
-    t1s = ts ++ tn ++ [::T_i32] /\ t2s = ts ++ tm.
-Proof.
-  move => i C t1s t2s HType.
-  dependent induction HType; subst => //=.
-  - by exists t1s0, t2s, [::].
-  - invert_be_typing.
-    by apply IHHType2 => //=.
-  - edestruct IHHType => //=.
-    destruct H as [tm [ts' [H1 [H2 [H3 [H4 H5]]]]]]. subst.
-    exists x, tm, (ts ++ ts').
-    by repeat rewrite -catA.
 Qed.
 
 End Host.


### PR DESCRIPTION
Removed many lemmas from the unnecessary host scope, and added them into the typing inversion tactic; improved naming of variables and hypothesis of the typing inversion tactic so that the generated names are more informative.