### PR TITLE
Tweak imports

### DIFF
--- a/theories/host.v
+++ b/theories/host.v
@@ -3,7 +3,7 @@
 
 From mathcomp Require Import ssreflect ssrfun ssrnat ssrbool eqtype seq.
 From Wasm Require Import common datatypes operations typing.
-From ITree Require Import ITree ITreeFacts.
+From ExtLib Require Import Structures.Monad.
 
 (* XXX unused? *)
 (* Import Monads. *)

--- a/theories/list_extra.v
+++ b/theories/list_extra.v
@@ -4,6 +4,7 @@
 Set Implicit Arguments.
 
 From Coq Require Import List.
+From ExtLib Require Import Structures.Monad.
 
 (** Given list of option types, check that all options are [Some]
    and return the corresponding list of values. **)
@@ -114,12 +115,8 @@ Definition fold_lefti {A B} (f : nat -> A -> B -> A) (xs : list B) (acc0 : A) : 
       (0, acc0) in
   acc_end.
 
-From ITree Require ITree ITreeFacts.
-
 Section Monad.
 
-Import ITree ITreeFacts.
-Import Monads.
 Import MonadNotation.
 
 Open Scope monad_scope.


### PR DESCRIPTION
the combination of the `ITree` library and some other library I'm using causes a Universe Inconsistency error.

This PR removes unnecessary Imports of the `ITree` library from unrelated files.
It seems, the `ITree` imports are just present as it re-exports the Monads from `coq-ext-lib` which are used.

Your reorganisation is quite nice, i.e. that the `ITree` lib is only used in the specific files :)

For this to be useful, I'd be grateful for a release at some point.