### PR TITLE
Abstract implementation of vector operations

### DIFF
--- a/theories/operations.v
+++ b/theories/operations.v
@@ -450,6 +450,57 @@ Definition app_relop (op: relop) (v1: value_num) (v2: value_num) :=
     end
   end.
 
+Definition app_unop_vec (op: unop_vec) (v1: value_vec) : value_vec :=
+  v1.
+
+Definition app_binop_vec (op: binop_vec) (v1 v2: value_vec) : value_vec :=
+  v1.
+
+Definition app_ternop_vec (op: ternop_vec) (v1 v2 v3: value_vec) : value_vec :=
+  v1.
+
+Definition app_test_vec (op: test_vec) (v1: value_vec) : bool :=
+  true.
+
+Definition app_shift_vec (op: shift_vec) (v1: value_vec) (v2: i32) : value_vec :=
+  v1.
+
+Definition app_splat_vec (shape: shape_vec) (v1: value_num) : value_vec :=
+  VAL_vec128 tt.
+
+Definition app_extract_vec (shape: shape_vec) (s: option sx) (n: laneidx) (v1: value_vec) : value_num :=
+  match shape with
+  | SV_ishape svi =>
+      match svi with
+      | SVI_64_2 => bitzero T_i64
+      | _ => bitzero T_i32
+      end
+  | SV_fshape svf =>
+      match svf with
+      | SVF_32_4 => bitzero T_f32
+      | SVF_64_2 => bitzero T_f64
+      end
+  end.
+
+Definition app_replace_vec (shape: shape_vec) (n: laneidx) (v1: value_vec) (v2: value_num) : value_vec :=
+  v1.
+
+Definition shape_dim (shape: shape_vec) : N :=
+  match shape with
+  | SV_ishape svi =>
+      match svi with
+      | SVI_8_16 => 16
+      | SVI_16_8 => 8
+      | SVI_32_4 => 4
+      | SVI_64_2 => 2
+      end
+  | SV_fshape svf =>
+      match svf with
+      | SVF_32_4 => 4
+      | SVF_64_2 => 2
+      end
+  end.
+
 Definition rglob_is_mut (g : module_global) : bool :=
   g.(modglob_type).(tg_mut) == MUT_var.
 

--- a/theories/opsem.v
+++ b/theories/opsem.v
@@ -54,6 +54,34 @@ Inductive reduce_simple : seq administrative_instruction -> seq administrative_i
     eval_cvt t2 op sx v = None ->
     reduce_simple [::$VN v; AI_basic (BI_cvtop t2 op t1 sx)] [::AI_trap]
 
+  (** vector instructions **)
+  | rs_unop_vec: 
+    forall v op,
+    reduce_simple [:: $VV v; AI_basic (BI_unop_vec op)] [::$VV (app_unop_vec op v)]
+  | rs_binop_vec: 
+    forall v1 v2 op,
+    reduce_simple [:: $VV v1; $VV v2; AI_basic (BI_binop_vec op)] [::$VV (app_binop_vec op v1 v2)]
+  | rs_ternop_vec: 
+    forall v1 v2 v3 op,
+    reduce_simple [:: $VV v1; $VV v2; $VV v3; AI_basic (BI_binop_vec op)] [::$VV (app_binop_vec op v1 v2)]
+  | rs_test_vec: 
+    forall v1 op,
+    reduce_simple [:: $VV v1; AI_basic (BI_test_vec op)] [::$VN (VAL_int32 (wasm_bool (app_test_vec op v1)))]
+  | rs_shift_vec: 
+    forall v1 v2 op,
+    reduce_simple [:: $VV v1; $VN (VAL_int32 v2); AI_basic (BI_shift_vec op)] [::$VV app_shift_vec op v1 v2]
+  | rs_splat_vec: 
+    forall v1 shape,
+    reduce_simple [:: $VN v1; AI_basic (BI_splat_vec shape)] [::$VV (app_splat_vec shape v1)]
+  | rs_extract_vec: 
+    forall v1 shape sx x,
+    N.lt x (shape_dim shape) ->
+    reduce_simple [:: $VV v1; AI_basic (BI_extract_vec shape sx x)] [::$VN (app_extract_vec shape sx x v1)]
+  | rs_replace_vec: 
+    forall v1 v2 shape x,
+    N.lt x (shape_dim shape) ->
+    reduce_simple [:: $VV v1; $VN v2; AI_basic (BI_replace_vec shape x)] [::$VV (app_replace_vec shape x v1 v2)]
+    
   (** reference operations **)
   | rs_ref_is_null_true:
     forall t,

--- a/theories/typing.v
+++ b/theories/typing.v
@@ -79,6 +79,22 @@ Definition value_typing (s: store_record) (v: value) (t: value_type) : bool :=
 Definition values_typing (s: store_record) (vs: list value) (tf: list value_type) : bool :=
   all2 (value_typing s) vs tf.
 
+Definition typeof_shape_unpacked (shape: shape_vec) : number_type :=
+  match shape with
+  | SV_ishape svi =>
+      match svi with
+      | SVI_8_16 => T_i32
+      | SVI_16_8 => T_i32
+      | SVI_32_4 => T_i32
+      | SVI_64_2 => T_i64
+      end
+  | SV_fshape svf =>
+      match svf with
+      | SVF_32_4 => T_f32
+      | SVF_64_2 => T_f64
+      end
+  end.
+  
 Definition result_types_agree (s: store_record) (ts : result_type) r : bool :=
   match r with
   | result_values vs => values_typing s vs ts
@@ -228,6 +244,24 @@ Inductive be_typing : t_context -> seq basic_instruction -> instr_type -> Prop :
 | bet_cvtop : forall C op t1 t2 sx,
     cvtop_valid t2 op t1 sx ->
     be_typing C [::BI_cvtop t2 op t1 sx] (Tf [::T_num t1] [::T_num t2])
+| bet_unop_vec: forall C op,
+    be_typing C [::BI_unop_vec op] (Tf [::T_vec T_v128] [::T_vec T_v128])
+| bet_binop_vec: forall C op,
+    be_typing C [::BI_binop_vec op] (Tf [::T_vec T_v128; T_vec T_v128] [::T_vec T_v128])
+| bet_ternop_vec: forall C op,
+    be_typing C [::BI_ternop_vec op] (Tf [::T_vec T_v128; T_vec T_v128; T_vec T_v128] [::T_vec T_v128])
+| bet_test_vec: forall C op,
+    be_typing C [::BI_test_vec op] (Tf [::T_vec T_v128] [::T_num T_i32])
+| bet_shift_vec: forall C op,
+    be_typing C [::BI_shift_vec op] (Tf [::T_vec T_v128; T_num T_i32] [::T_vec T_v128])
+| bet_splat_vec: forall C shape,
+    be_typing C [::BI_splat_vec shape] (Tf [::T_num (typeof_shape_unpacked shape)] [::T_vec T_v128])
+| bet_extract_vec: forall C shape sx x,
+    N.lt x (shape_dim shape) ->
+    be_typing C [::BI_extract_vec shape sx x] (Tf [::T_vec T_v128] [::T_num (typeof_shape_unpacked shape)])
+| bet_replace_vec: forall C shape x,
+    N.lt x (shape_dim shape) ->
+    be_typing C [::BI_replace_vec shape x] (Tf [::T_vec T_v128; T_num (typeof_shape_unpacked shape)] [::T_vec T_v128])
 | bet_unreachable : forall C ts ts',
   be_typing C [::BI_unreachable] (Tf ts ts')
 | bet_nop : forall C, be_typing C [::BI_nop] (Tf [::] [::])


### PR DESCRIPTION
This PR is for adding an abstract implementation of vector operations and updating the related definitions and proofs. The concrete executions are not implemented will be added in a future update. 

With this update, the binary format parser will now work on all Wasm 2.0 binaries.