### PR TITLE
Context interpreter refactors and cleanups

### DIFF
--- a/src/execute.ml
+++ b/src/execute.ml
@@ -147,7 +147,7 @@ let invocation_interpret verbosity error_code_on_crash hsfes (name: string) =
         | Some cfg_next -> 
             eval_cfg (gen+1) hs' cfg_next
         | None ->
-          debug_info verbosity stage ~style:red (fun _ -> "Configuration reformation failure\n");
+          debug_info verbosity stage ~style:red (fun _ -> "Configuration reformation failure; this should not happen for valid Wasm modules. Please file a bug report at GitHub/WasmCert-Coq.\n");
           pure None
         end
       | RSC_value (s, _f, vs) ->

--- a/src/execute.ml
+++ b/src/execute.ml
@@ -150,12 +150,12 @@ let invocation_interpret verbosity error_code_on_crash hsfes (name: string) =
           debug_info verbosity stage ~style:red (fun _ -> "Configuration reformation failure\n");
           pure None
         end
-      | RSC_value (hs, s, vs) ->
+      | RSC_value (s, _f, vs) ->
         debug_info verbosity stage ~style:green (fun _ -> "success after " ^ string_of_int gen ^ " steps\n");
         pure (Some (hs, s, vs))
-      | RSC_value_frame (hs, s, vs, _, _) ->
-        debug_info verbosity stage ~style:green (fun _ -> "success after " ^ string_of_int gen ^ " steps\n");
-        pure (Some (hs, s, vs))
+      | RSC_trap (_s, _f) ->
+        debug_info verbosity stage ~style:green (fun _ -> "trap after " ^ string_of_int gen ^ " steps\n");
+        pure None
       | RSC_invalid ->
         debug_info verbosity stage ~style:red (fun _ -> "Invalid cfg\n");
         pure None
@@ -167,8 +167,8 @@ let invocation_interpret verbosity error_code_on_crash hsfes (name: string) =
   debug_info verbosity intermediate (fun _ ->
     Printf.sprintf "\nPost-instantiation stage for table and memory initialisers...\n");
   
-  match run_v_init_with_frame s f_invocation O es_invocation with
-  | Some cfg_invocation -> 
+  match run_v_init_with_frame s f_invocation es_invocation with
+  | cfg_invocation -> 
     let* res = eval_cfg 1 hs cfg_invocation in
     begin match res with
     | Some (hs', s', _) ->
@@ -181,8 +181,8 @@ let invocation_interpret verbosity error_code_on_crash hsfes (name: string) =
             | None -> Error ("unknown function `" ^ name ^ "`")
             | Some es_init -> OK es_init)
             ) in
-      begin match run_v_init_with_frame s' Extract.empty_frame O es_init with
-      | Some cfg_init -> 
+      begin match run_v_init_with_frame s' Extract.empty_frame es_init with
+      | cfg_init -> 
         print_step_header 0 ;
         debug_info verbosity intermediate (fun _ ->
           Printf.sprintf "\nExecuting configuration:\n%s\n" (pp_cfg_tuple_ctx_except_store cfg_init));
@@ -193,12 +193,9 @@ let invocation_interpret verbosity error_code_on_crash hsfes (name: string) =
           | None -> "");
         if error_code_on_crash && (match res with None -> true | Some _ -> false) then exit 1
         else pure ()
-      | None -> Printf.printf "Unable to construct initial configuration for named function";
-      pure ()
       end
     | None -> Printf.printf "Invocation failed"; pure ()
     end
-  | None -> Printf.printf "Unable to construct initial configuration for invocation"; pure ()
 
 
 

--- a/src/shim.ml
+++ b/src/shim.ml
@@ -56,7 +56,7 @@ module type InterpreterType = sig
     store_record -> administrative_instruction list -> config_tuple option
 
   val run_v_init_with_frame : 
-    store_record -> frame -> Extract.nat -> administrative_instruction list -> config_tuple option
+    store_record -> frame -> administrative_instruction list -> config_tuple
 
   (** Look-up a specific extracted function of the instantiation. *)
   val lookup_exported_function :

--- a/src/shim.mli
+++ b/src/shim.mli
@@ -56,7 +56,7 @@ module type InterpreterType = sig
     store_record -> administrative_instruction list -> config_tuple option
 
   val run_v_init_with_frame : 
-    store_record -> frame -> Extract.nat -> administrative_instruction list-> config_tuple option
+    store_record -> frame -> administrative_instruction list-> config_tuple
 
   (** Look-up a specific extracted function of the instantiation. *)
   val lookup_exported_function :

--- a/theories/contexts.v
+++ b/theories/contexts.v
@@ -281,12 +281,13 @@ Definition oe_noframe (oe: option administrative_instruction) :=
  *)
 
 Definition valid_ccs (ccs: list closure_ctx): bool :=
-  match ccs with
+  ccs != nil.
+  (*match ccs with
   | nil => false
   | cc0 :: _ =>
       let '(fc, lcs) := last cc0 ccs in
       (fc.(FC_val) == nil) && (fc.(FC_post) == nil)
-  end.
+  end.*)
 
 Lemma valid_ccs_change_labs fc labs labs' ccs:
   valid_ccs ((fc, labs) :: ccs) ->
@@ -537,11 +538,11 @@ Proof.
     ]; simpl in *; try by (injection Hdecomp as <- <- <-; unfold valid_ccs).
   - destruct acc as [ | [fc lcs] ccs'] => //.
     eapply IH in Hdecomp; eauto; apply split_vals_inv in Hsplit as ->.
-    + by rewrite ais_measure_cat ais_measure_cons /ais_measure => /=; lias.
-    + by eapply valid_ccs_change_labs; eauto.
+    by rewrite ais_measure_cat ais_measure_cons /ais_measure => /=; lias.
+(*    + by eapply valid_ccs_change_labs; eauto. *)
   - eapply IH in Hdecomp; eauto; apply split_vals_inv in Hsplit as ->.
-    + by rewrite ais_measure_cat ais_measure_cons /ais_measure => /=; lias.
-    + by destruct acc.
+    by rewrite ais_measure_cat ais_measure_cons /ais_measure => /=; lias.
+(*    + by destruct acc. *)
 Qed.
 
 Lemma ctx_decompose_valid_aux: forall ves acc ccs sctx oe,
@@ -600,9 +601,9 @@ Proof.
   (* Label *)
   - destruct ccs as [ | [fc lcs] ccs0] => //.
     eapply ctx_decompose_valid_ccs_aux in Hupdate; eauto.
-    by eapply valid_ccs_change_labs; eauto.
+    (*by eapply valid_ccs_change_labs; eauto.*)
   - eapply ctx_decompose_valid_ccs_aux in Hupdate; eauto.
-    by destruct ccs.
+   (* by destruct ccs. *)
 Qed.
   
 Lemma ctx_update_nconst_valid: forall sctx e ccs ccs' sctx' oe,
@@ -804,35 +805,6 @@ Lemma lh_ctx_fill: forall lcs es lf,
 Proof.
   intros lcs es lf Hctx.
   by apply lh_ctx_fill_aux with (acc := LH_base nil nil) => /=; rewrite cats0.
-Qed.
-
-(** context reduction lemmas **)
-
-Lemma reduce_focus_ctx: forall hs s lcs ccs es hs' s' lcs' es' f0 fc fc',
-    fc.(FC_val) = fc'.(FC_val) ->
-    fc.(FC_post) = fc'.(FC_post) ->
-    fc.(FC_arity) = fc'.(FC_arity) ->
-    reduce hs s fc.(FC_frame) (lcs ⦃ es ⦄) hs' s' fc'.(FC_frame) (lcs' ⦃ es' ⦄) ->
-    reduce hs s f0 (((fc, lcs) :: ccs) ⦃ es ⦄) hs' s' f0 (((fc', lcs') :: ccs) ⦃ es' ⦄).
-Proof.
-  intros ???????????? Heqval Heqpost Heqarity => /=.
-  rewrite - Heqpost -Heqval -Heqarity.
-  move => Hred.
-  apply (list_closure_ctx_eval.(ctx_reduce)) with (hs := hs) => //.
-  eapply r_label with (lh := LH_base (rev (FC_val fc)) (FC_post fc)) => /=; try by (f_equal; rewrite -cat1s; eauto).
-  by apply r_frame.
-Qed.
-
-Lemma reduce_focus_ctx_id: forall hs s lcs ccs es hs' s' es' f0 fc fc',
-    fc.(FC_val) = fc'.(FC_val) ->
-    fc.(FC_post) = fc'.(FC_post) ->
-    fc.(FC_arity) = fc'.(FC_arity) ->
-    reduce hs s fc.(FC_frame) es hs' s' fc'.(FC_frame) es' ->
-    reduce hs s f0 (((fc, lcs) :: ccs) ⦃ es ⦄) hs' s' f0 (((fc', lcs) :: ccs) ⦃ es' ⦄).
-Proof.
-  intros ??????????? Heqval Heqpost Heqarity Hred.
-  apply reduce_focus_ctx => //.
-  by apply (list_label_ctx_eval.(ctx_reduce)).
 Qed.
 
 

--- a/theories/interpreter_ctx.v
+++ b/theories/interpreter_ctx.v
@@ -57,7 +57,8 @@ Proof.
   by unfold inst_typing in Hoption; destruct f, f_inst, t; unfold upd_return, upd_local, upd_local_label_return in *; simpl in *; remove_bools_options.
 Qed.
 
-(* Context typing inversion lemma *)
+(* Context typing inversion lemma. The first version preserves the original
+   type label context, where as the second version focuses on the innermost label. *)
 Lemma ctx_cfg_inv_lcs: forall s cc ccs sc oe ts,
     ctx_cfg_typing (s, (cc :: ccs), sc, oe) ts ->
     exists C (ret: option result_type) ts2,
@@ -119,22 +120,7 @@ Proof.
     by erewrite frame_typing_label_empty, cats0; eauto.
 Qed.
 
-(*
-(** Auxiliary definition for reductions between context tuples.
-    Technically there's an auxiliary empty frame added; but that allows precisely
-    the same set of instructions.
- **)
-Definition reduce_ctx (hs hs': host_state) (cfg cfg': cfg_tuple_ctx) : Prop :=
-  match cfg with
-  | (s, ccs, sc, oe) =>
-      match cfg' with
-      | (s', ccs', sc', oe') => reduce hs s empty_frame (ccs ⦃ sc ⦃ olist oe ⦄ ⦄) hs' s' empty_frame (ccs' ⦃ sc' ⦃ olist oe' ⦄ ⦄)
-      end
-  end.
-*)
-
 (** Auxiliary definition for reductions between context tuples. **)
-
 Definition reduce_ctx (hs hs': host_state) (cfg cfg': cfg_tuple_ctx) : Prop :=
   match ctx_to_cfg cfg with
   | Some (s, (f, es)) =>
@@ -147,6 +133,7 @@ Definition reduce_ctx (hs hs': host_state) (cfg cfg': cfg_tuple_ctx) : Prop :=
   end.
 
 (** ctx reduction lemmas **)
+(* ctxs reduction can be focused in any partial initial fragments with a pivot cc. *)
 Lemma reduce_focus_pivot ccs0 ccs1: forall hs hs' s ccs sc oe s' sc' oe' cc0 cc0',
     cc0.1.(FC_val) = cc0'.1.(FC_val) ->
     cc0.1.(FC_post) = cc0'.1.(FC_post) ->
@@ -196,53 +183,6 @@ Proof.
   apply reduce_focus => //.
   by apply (list_label_ctx_eval.(ctx_reduce)) with (hs := hs) => //.
 Qed.
-
-(*
-(* The reduction of a combined frame and instructions projects back to a reduction 
-   between the original thread setups. *)
-Lemma reduce_fes_thread hs hs' s s' fes fes' f es f' es' f0 f0':
-  reduce hs s f0 fes hs' s' f0' fes' ->
-  fes_to_thread fes = Some (f, es) ->
-  fes_to_thread fes' = Some (f', es') ->
-  reduce hs s f es hs' s' f' es'.
-Proof.
-  move => Hred Hthread1 Hthred2.
-  unfold fes_to_thread in *.
-  destruct fes => //; destruct a => //; destruct fes => //.
-  destruct fes' => //; destruct a => //; destruct fes' => //.
-  remove_bools_options.
-  remember [::AI_frame n f es] as les.
-  remember [::AI_frame n0 f' es'] as les'.
-  induction Hred; subst => //.
-  - by inversion H; subst; clear H => //.
-  - by repeat (destruct vs as [|? vs] => //).
-  - by repeat (destruct vcs as [|? vcs] => //).
-  - destruct lh; simpl in *.
-    + destruct l as [ | ? l] => //; simpl in *; last by repeat destruct v => //.
-      destruct es0 as [|e es0]; first by apply reduce_not_nil in Hred.
-      destruct es0, l0 => //.
-      rewrite cats0 in H0; simpl in H; inversion H; subst.
-      by eapply IHHred; eauto.
-    + by repeat destruct l => //.
-  - by inversion Heqles; inversion Heqles'; subst.
-Qed.
-
-Lemma valid_ccs_thread ccs es:
-  valid_ccs ccs ->
-  exists f es', fes_to_thread (ccs ⦃ es ⦄) = Some (f, es').
-Proof.
-  unfold valid_ccs.
-  destruct ccs as [|cc ccs] => //.
-  move => Hvalid.
-  destruct (cc :: ccs) eqn:Hlast using last_ind => //.
-  rewrite last_rcons in Hvalid.
-  simpl.
-  rewrite foldl_rcons => /=.
-  destruct x as [fc lcs]; destruct fc; simpl in *.
-  remove_bools_options; subst.
-  by repeat eexists.
-Qed.
- *)
 
 Ltac red_ctx_simpl :=
   repeat lazymatch goal with
@@ -299,7 +239,7 @@ Ltac infer_hole :=
 
 
 Ltac resolve_reduce_ctx vs es :=
-  unfold reduce_ctx; try (eapply r_label with (lh := LH_base (rev vs) es) => /=; infer_hole).
+  try apply reduce_focus_id => //; try (eapply r_label with (lh := LH_base (rev vs) es) => /=; infer_hole).
 
 Ltac resolve_valid_ccs :=
   repeat lazymatch goal with
@@ -319,13 +259,20 @@ Definition es_of_cfg (cfg: cfg_tuple_ctx) :=
   | (_, ccs, sc, oe) => ccs ⦃ sc ⦃ olist oe ⦄ ⦄
   end.
 
+Definition valid_ccs_cfg (cfg: cfg_tuple_ctx) :=
+  let '(s, ccs, sc, oe) := cfg in
+  ccs <> nil.
+
 Inductive run_step_ctx_result (hs: host_state) (cfg: cfg_tuple_ctx): Type :=
 | RSC_normal hs' cfg':
   reduce_ctx hs hs' cfg cfg' ->
-(*  valid_cfg_ctx cfg' ->*)
+  valid_ccs_cfg cfg' ->
   run_step_ctx_result hs cfg
 | RSC_value s f vs:
   ctx_to_cfg cfg = Some (s, (f, v_to_e_list vs)) ->
+  run_step_ctx_result hs cfg
+| RSC_trap s f:
+  ctx_to_cfg cfg = Some (s, (f, [::AI_trap])) ->
   run_step_ctx_result hs cfg
 | RSC_invalid :
   (valid_cfg_ctx cfg -> False) ->
@@ -334,25 +281,6 @@ Inductive run_step_ctx_result (hs: host_state) (cfg: cfg_tuple_ctx): Type :=
   (forall ts, ctx_cfg_typing cfg ts -> False) ->
   run_step_ctx_result hs cfg
 .
-
-Ltac invert_ctx_typing Hetype0 :=
-  match type of Hetype0 with
-  | e_typing _ _ ((_ :: _) ⦃ _ ⦃ _ ⦄ ⦄) _ =>
-    let vts := fresh "vts" in
-    let ts' := fresh "ts'" in
-    let Hvtsype := fresh "Hvtsype" in
-    let Hftype := fresh "Hftype" in
-    let Hetype := fresh "Hetype" in
-    let Harity := fresh "Harity" in
-    apply e_typing_ops_local in Hetype0 as [? [? [? [? [vts [ts' [Hvtstype [Hftype [Harity [? Hetype]]]]]]]]]]
-  | e_typing _ _ (_ ⦃ _ ⦃ _ ⦄ ⦄) (Tf nil _) =>
-    let vts := fresh "vts" in
-    let ts' := fresh "ts'" in
-    let Hvtsype := fresh "Hvtsype" in
-    let Hetype := fresh "Hetype" in
-    apply e_typing_ops in Hetype0 as [? [vts [ts' [Hvtstype Hetype]]]]
-  end;
-  simpl in *; invert_e_typing; remove_bools_options.
 
 (** The usual start of a crash certification **)
 Ltac resolve_invalid_typing :=
@@ -376,22 +304,6 @@ Ltac resolve_invalid_typing :=
   apply ctx_cfg_inv in Htype as [C [ret [labs [ts' [Hstype [Hftype [Hagree [Hretcons [Hretnil Hetype]]]]]]]]];
   eapply sc_typing_args in Hetype as [ts3 [ts4 [Hvstype Hetype]]]; simpl in Hetype;
   invert_e_typing.
-
-Ltac last_unequal H :=
-  apply (f_equal rev) in H;
-  repeat rewrite rev_cat in H;
-  repeat rewrite -map_rev in H;
-  repeat rewrite rev_drop in H;
-  repeat rewrite revK in H;
-  repeat rewrite size_rev in H;
-  repeat rewrite map_take in H;
-  simpl in H;
-  (try by inversion H);
-  match type of H with
-  | context C [take ?n _] =>
-      try by destruct n
-  | _ => fail "unable to obtain a contradiction"
-  end.
 
 Notation "<< hs , cfg >>" := (@RSC_normal _ _ hs cfg).
 
@@ -492,7 +404,7 @@ Proof.
   - clear IHccs'.
     destruct fc as [lvs lk lf les].
     destruct (lk <= length vs) eqn:Hvslen.
-    + apply <<hs, (s, rcons ccs' cc0, (take lk vs ++ lvs, les), None)>> => //=.
+    + apply <<hs, (s, rcons ccs' cc0, (take lk vs ++ lvs, les), None)>> => //=; last by destruct ccs'.
       unfold reduce_ctx => /=.
       rewrite rev_cons rev_rcons rcons_cons.
       destruct cc0 as [[fvs0 fk0 ff0 fes0] lcs0].
@@ -528,8 +440,9 @@ Proof.
       (* true *)
       * destruct (split_n vs0 n) as [vs' vs''] eqn:Hsplit.
         destruct (default_vals ts) as [zs |] eqn:Hdefault.
-        (* types are all defaultable as of Wasm 2.0 *)
-        { apply <<hs, (s, (Build_frame_ctx vs'' m (Build_frame (rev vs' ++ zs) i) es0, nil) :: (fc, lcs) :: ccs', (nil, nil), Some (AI_label m nil (to_e_list es)))>> => /=.
+        (* types are all defaultable as of Wasm 2.0. This potentially needs a 
+           small change in 3.0. *)
+        { apply <<hs, (s, (Build_frame_ctx vs'' m (Build_frame (rev vs' ++ zs) i) es0, nil) :: (fc, lcs) :: ccs', (nil, nil), Some (AI_label m nil (to_e_list es)))>> => //=.
           apply (@reduce_focus_pivot nil ([::(Build_frame_ctx vs'' m _ es0, nil)])) => //=.
           apply (list_label_ctx_eval.(ctx_reduce)) => //=.
           rewrite split_n_is_take_drop in Hsplit; injection Hsplit as <- <-.
@@ -566,7 +479,7 @@ Proof.
         destruct (host_application_impl hs s (Tf t1s t2s) cl' (rev vs')) as [hs' [[s' rves]|]] eqn:?.
         -- (* (hs', Some (s', rves)) *)
           destruct rves as [rvs | ].
-          ++ apply <<hs', (s', (fc, lcs) :: ccs', (rev rvs ++ vs'', es0), None)>> => /=.
+          ++ apply <<hs', (s', (fc, lcs) :: ccs', (rev rvs ++ vs'', es0), None)>> => //=.
              apply reduce_focus_id => //.
              rewrite split_n_is_take_drop in Hsplit.
              injection Hsplit as ??.
@@ -580,7 +493,7 @@ Proof.
              eapply r_invoke_host_success; eauto.
              repeat rewrite length_is_size.
              by rewrite size_rev size_takel => //.
-          ++ apply <<hs', (s', (fc, lcs) :: ccs', (vs'', es0), Some AI_trap)>> => /=.
+          ++ apply <<hs', (s', (fc, lcs) :: ccs', (vs'', es0), Some AI_trap)>> => //=.
              apply reduce_focus_id => //.
              rewrite split_n_is_take_drop in Hsplit.
              injection Hsplit as ??.
@@ -594,7 +507,7 @@ Proof.
              repeat rewrite length_is_size.
              by rewrite size_rev size_takel => //.
   - (* (hs', None) *)
-    apply <<hs', (s, (fc, lcs) :: ccs', (vs'', es0), Some AI_trap)>> => /=.
+    apply <<hs', (s, (fc, lcs) :: ccs', (vs'', es0), Some AI_trap)>> => //=.
     apply reduce_focus_id => //.
     rewrite split_n_is_take_drop in Hsplit.
     injection Hsplit as ??.
@@ -744,28 +657,28 @@ Notation "$nou32 v" := (Wasm_int.N_of_uint i32m v) (at level 90).
 (* One step of execution; does not perform the context update in the end to shift to the new instruction nor the validity check. *)
 Definition run_one_step_ctx (hs: host_state) (cfg: cfg_tuple_ctx) : run_step_ctx_result hs cfg.
 Proof.
-  destruct cfg as [[[s ccs] [vs es]] oe].
+  destruct cfg as [[[s ccs] [vs0 es0]] oe].
   get_cc ccs.
   destruct oe as [e | ]; last first.
   (* Empty hole -- exiting from contexts *)
   {
-    destruct es as [ | ??]; last by apply RSC_invalid => /=; move => [??].
+    destruct es0 as [ | ??]; last by apply RSC_invalid => /=; move => [??].
     { destruct lcs as [ | lc lcs'].
       {
         (* Exiting from frame -- we need to check if this is the last frame first *)
         destruct ccs' as [| cc ccs'].
         (* No more frames -- terminate *)
-        { apply (@RSC_value _ _ s fc.(FC_frame) (rev vs)) => /=.
+        { apply (@RSC_value _ _ s fc.(FC_frame) (rev vs0)) => /=.
           by destruct fc; rewrite cats0.
         }
         (* At least a frame left -- in this case, determine if the length of values match the arity *)
         {
           destruct fc as [lvs lk lf les].
-          destruct (length vs == lk) eqn:Hlen; move/eqP in Hlen.
+          destruct (length vs0 == lk) eqn:Hlen; move/eqP in Hlen.
           {
             (* Exiting the frame now. Note that this implementation does not 
-               attempt to directly construct the next valid cfg (les can be non-empty) *)
-            apply <<hs, (s, cc :: ccs', (vs ++ lvs, les), None)>> => /=.
+               attempt to directly construct the next canonical cfg (les can be non-empty) *)
+            apply <<hs, (s, cc :: ccs', (vs0 ++ lvs, les), None)>> => //=.
             apply (@reduce_focus_pivot [:: (Build_frame_ctx lvs lk lf les, nil)] nil) => //=.
             apply (list_label_ctx_eval.(ctx_reduce)) => //=.
             repeat rewrite cats0.
@@ -774,39 +687,26 @@ Proof.
           }
           {
             apply RSC_error; move => ts Hetype.
-            unfold ctx_cfg_typing in Hetype; remove_bools_options.
-            destruct c as [s' [f es]].
-            simpl in *.
-            destruct
-            
-            simpl in *.
-            specialize (Hretcons isT).
+            apply ctx_cfg_inv_lcs in Hetype as [C [ret [ts2 [Hstype [Hftype [Hretcons [_ Hetype]]]]]]]; simpl in *.
+            specialize (Hretcons isT) as [-> Harity]; simpl in Harity; injection Harity as <-.
+            rewrite cats0 in Hetype.
+            unfold vs_to_es in Hetype.
+            invert_e_typing.
             by discriminate_size.
-          }
           }
         }
       }
       (* Exitting a label *)
+      (* It is futile to try to push the next instruction e from lvs into the hole,
+         as that might be a value anyway *)
       { destruct lc as [lvs lk lces les].
-        destruct les as [ | e les'].
-        { (* No instruction in the hole still *)
-          apply <<hs, (s, (fc, lcs') :: ccs', (vs ++ lvs, nil), None)>> => /=.
-          resolve_reduce_ctx (FC_val fc) (FC_post fc).
-          eapply r_frame.
-          apply reduce_focus_id => //=.
-          unfold fmask0, label_ctx_fill => /=.
-          eapply r_label with (lh := LH_base (rev lvs) nil) => /=; infer_hole; eauto => /=.
-          apply r_simple, rs_label_const; by apply v_to_e_const.
-        }
-        { (* e is in the hole *)
-          apply <<hs, (s, (fc, lcs') :: ccs', (vs ++ lvs, les'), Some e)>> => /=.
-          resolve_reduce_ctx (FC_val fc) (FC_post fc).
-          apply r_frame => /=.
-          apply reduce_focus_id => //=.
-          unfold fmask0, label_ctx_fill => /=.
-          eapply r_label with (lh := LH_base (rev lvs) (e :: les')) => /=; infer_hole.
-          apply r_simple, rs_label_const; by apply v_to_e_const.
-        }
+        apply <<hs, (s, (fc, lcs') :: ccs', (vs0 ++ lvs, les), None)>> => //=.
+        apply reduce_focus => //=.
+        apply (list_label_ctx_eval.(ctx_reduce)) => //=.
+        repeat rewrite cats0.
+        unfold fmask0, label_ctx_fill => /=.
+        resolve_reduce_ctx lvs les.
+        apply r_simple, rs_label_const; by apply v_to_e_const.
       }
     }
   }
@@ -862,118 +762,117 @@ Proof.
       (* AI_ref_extern a *) a |
       (* AI_invoke a *) a |
       (* AI_label ln les es *) ln les es |
-      (* AI_frame ln lf es *) ln lf es ]; destruct sc as [vs0 es0].
+      (* AI_frame ln lf es *) ln lf es ].
 
-    - (* AI_basic (BI_const _) *)
-      (* This along with other value instructions are invalid, as it doesn't respect
+    (* AI_basic (BI_const _) *)
+    (* This along with other value instructions are invalid, as it doesn't respect
 the condition that all values should live in the operand stack. *)
-      apply RSC_invalid => /=; by move => [??].
+    - apply RSC_invalid => /=; by move => [??].
 
-    - (* AI_basic (BI_unop t op) *)
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_unop t op) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_value_num v.
       (* v :: ves' *)
-      apply <<hs, (s, ccs, (VAL_num (app_unop op v) :: vs0, es0), None)>>.
+      apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (app_unop op v) :: vs0, es0), None)>> => //.
       resolve_reduce_ctx vs0 es0.
       by apply r_simple, rs_unop.
 
-    - (* AI_basic (BI_binop t op) *)
-      destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
+    (* AI_basic (BI_binop t op) *)
+    - destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
       assert_value_num v2.
       assert_value_num v1.
       (* [:: v2, v1 & ves'] *)
       destruct (app_binop op v1 v2) as [v|] eqn:?.
-      + (* Some v *)
-        apply <<hs, (s, ccs, (VAL_num v :: vs0, es0), None)>>.
+      (* Some v *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num v :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple, rs_binop_success.
-      + (* None *)
-        apply <<hs, (s, ccs, (vs0, es0), Some AI_trap)>>.
+      (* None *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple, rs_binop_failure.
 
-    - (* AI_basic (BI_testop t testop) *)
-      destruct vs0 as [| v vs0]; first by no_args.
+    (* AI_basic (BI_testop t testop) *)
+    - destruct vs0 as [| v vs0]; first by no_args.
       (* v :: ves' *)
       assert_value_num v.
       destruct t as [| | |].
-      3,4: by resolve_invalid_typing; last_unequal H1_testop.
+      3,4: by resolve_invalid_typing.
       (* i32 *)
       + destruct v as [c| | |].
         2,3,4: by resolve_invalid_typing; resolve_invalid_value. 
-        apply <<hs, (s, ccs, (VAL_num (VAL_int32 (wasm_bool (@app_testop_i i32t testop c))) :: vs0, es0), None)>>.
+        apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 (wasm_bool (@app_testop_i i32t testop c))) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple, rs_testop_i32.
       (* i64 *)
       + destruct v as [|c | |].
         1,3,4: by resolve_invalid_typing; resolve_invalid_value.
-        apply <<hs, (s, ccs, (VAL_num (VAL_int32 (wasm_bool (@app_testop_i i64t testop c))) :: vs0, es0), None)>>.
+        apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 (wasm_bool (@app_testop_i i64t testop c))) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple, rs_testop_i64.
 
-    - (* AI_basic (BI_relop t op) *)
-      destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
+    (* AI_basic (BI_relop t op) *)
+    - destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
       assert_value_num v2.
       assert_value_num v1.
       (* [:: v2, v1 & ves'] *)
-      apply <<hs, (s, ccs, (VAL_num (VAL_int32 (wasm_bool (@app_relop op v1 v2))) :: vs0, es0), None)>>.
+      apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 (wasm_bool (@app_relop op v1 v2))) :: vs0, es0), None)>> => //.
       resolve_reduce_ctx vs0 es0.
       by apply r_simple, rs_relop.
 
-    - (* AI_basic (BI_cvtop t2 CVO_convert t1 sx) *)
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_cvtop t2 CVO_convert t1 sx) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_value_num v.
       (* v :: ves' *)
       destruct (typeof_num v == t1) eqn:Ht1; move/eqP in Ht1.
-      + (* true *)
-        destruct (cvtop_valid t2 cvtop t1 sx) eqn:Hcvtvalid.
-        * (* true *)
-          destruct (eval_cvt t2 cvtop sx v) as [v'|] eqn:Heval.
-          { (* Some v' *)
-            apply <<hs, (s, ccs, (VAL_num v' :: vs0, es0), None)>>.
+      (* true *)
+      + destruct (cvtop_valid t2 cvtop t1 sx) eqn:Hcvtvalid.
+        (* true *)
+        * destruct (eval_cvt t2 cvtop sx v) as [v'|] eqn:Heval.
+          (* Some v' *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num v' :: vs0, es0), None)>> => //.
             resolve_reduce_ctx vs0 es0.
             by apply r_simple, rs_convert_success.
           }
-          { (* None *)
-            apply <<hs, (s, ccs, (vs0, es0), Some AI_trap)>>.
+          (* None *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
             resolve_reduce_ctx vs0 es0.
             by apply r_simple, rs_convert_failure.
           }
-        * (* false *)
-          by resolve_invalid_typing; lias.
-      + (* false *)
-        discriminate_value_type.
+        (* false *)
+        * by resolve_invalid_typing; lias.
+      (* false *)
+      + discriminate_value_type.
         apply num_subtyping in H; by inversion H; subst.
 
-    - (* AI_basic BI_const_vec v *)
-      apply RSC_invalid => /=; by move => [??].
+    (* AI_basic BI_const_vec v *)
+    - apply RSC_invalid => /=; by move => [??].
       
-    - (* AI_basic BI_ref_null t *)
-      apply RSC_invalid => /=; by move => [??].
+    (* AI_basic BI_ref_null t *)
+    - apply RSC_invalid => /=; by move => [??].
 
-    - (* AI_basic BI_ref_is_null *)
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic BI_ref_is_null *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_value_ref v.
       destruct v as [ v | v | v ].
       (* ref_null *)
-      + apply <<hs, (s, ccs, ((VAL_num (VAL_int32 Wasm_int.Int32.one)) :: vs0, es0), None)>>.
+      + apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_num (VAL_int32 Wasm_int.Int32.one)) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple, rs_ref_is_null_true.
       (* ref_func *)
-      + apply <<hs, (s, ccs, ((VAL_num (VAL_int32 Wasm_int.Int32.zero)) :: vs0, es0), None)>>.
+      + apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_num (VAL_int32 Wasm_int.Int32.zero)) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         replace (AI_ref v) with ($V (VAL_ref (VAL_ref_func v))) => //.
         by apply r_simple, rs_ref_is_null_false.
       (* ref_extern *)
-      + apply <<hs, (s, ccs, ((VAL_num (VAL_int32 Wasm_int.Int32.zero)) :: vs0, es0), None)>>.
+      + apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_num (VAL_int32 Wasm_int.Int32.zero)) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         replace (AI_ref_extern v) with ($V (VAL_ref (VAL_ref_extern v))) => //.
         by apply r_simple, rs_ref_is_null_false.
 
-    - (* AI_basic (BI_ref_func x) *)
-      get_cc ccs.
-      destruct (lookup_N (inst_funcs (f_inst fc.(FC_frame))) x) as [addr | ] eqn:Hnth.
-      + apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_ref (VAL_ref_func addr)) :: vs0, es0), None)>>.
+    (* AI_basic (BI_ref_func x) *)
+    - destruct (lookup_N (inst_funcs (f_inst fc.(FC_frame))) x) as [addr | ] eqn:Hnth.
+      + apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_ref (VAL_ref_func addr)) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_ref_func.
       + resolve_invalid_typing.
@@ -981,136 +880,129 @@ the condition that all values should live in the operand stack. *)
         eapply inst_typing_func_lookup_inv in Hconjl0 as [f [Hext Hnthf]]; eauto.
         by rewrite Hnthf in Hnth.
       
-    - (* AI_basic BI_drop *)
-      destruct vs0 as [ | v vs0]; first by no_args.
+    (* AI_basic BI_drop *)
+    - destruct vs0 as [ | v vs0]; first by no_args.
       (* v :: vs0 *)
-      apply <<hs, (s, ccs, (vs0, es0), None)>> => /=.
+      apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>> => //=.
       resolve_reduce_ctx vs0 es0.
       by apply r_simple, rs_drop.
       
-    - (* AI_basic BI_select *)
-      destruct vs0 as [|v3 [|v2 [|v1 vs0]]]; try by no_args.
+    (* AI_basic BI_select *)
+    - destruct vs0 as [|v3 [|v2 [|v1 vs0]]]; try by no_args.
 
       (* v3 has to be i32, but the other two can be of any numeric type. Note that neitehr the spec nor the opsem checks for this during runtime *)
       assert_i32 v3.
       (* VAL_int32 c *)
       destruct (v3 == Wasm_int.int_zero i32m) eqn:Heq0; move/eqP in Heq0.
-      + (* true *)
-        apply <<hs, (s, ccs, (vs0, es0), Some ($V v2))>> => /=.
+      (* true *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some ($V v2))>> => //=.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple; apply rs_select_false.
       + (* false *)
-        apply <<hs, (s, ccs, (vs0, es0), Some ($V v1))>> => /=.
+        apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some ($V v1))>> => //=.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple; apply rs_select_true.
         
-    - (* AI_basic (BI_local_get j) *)
-      get_cc ccs.
-      destruct (lookup_N fc.(FC_frame).(f_locs) j) as [vs_at_j|] eqn:?.
-      * (* Some vs_at_j *)
-        apply <<hs, (s, (fc, lcs) :: ccs', (vs_at_j :: vs0, es0), None)>>.
+    (* AI_basic (BI_local_get j) *)
+    - destruct (lookup_N fc.(FC_frame).(f_locs) j) as [vs_at_j|] eqn:?.
+      (* Some vs_at_j *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs_at_j :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by eapply r_local_get; subst.
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         erewrite inst_t_context_local_empty in Hconjr; eauto.
         by discriminate_size.
         
-    - (* AI_basic (BI_local_set j) *)
-      get_cc ccs.    
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_local_set j) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       (* v :: ves' *)
       destruct (N.to_nat j < length fc.(FC_frame).(f_locs)) eqn:Hlen.
-      + (* true *)
-        apply <<hs, (s, ((Build_frame_ctx (fc.(FC_val)) fc.(FC_arity) (Build_frame (set_nth v fc.(FC_frame).(f_locs) (N.to_nat j) v) fc.(FC_frame).(f_inst)) fc.(FC_post)), lcs) :: ccs', (vs0, es0), None)>>.
+      (* true *)
+      + apply <<hs, (s, ((Build_frame_ctx (fc.(FC_val)) fc.(FC_arity) (Build_frame (set_nth v fc.(FC_frame).(f_locs) (N.to_nat j) v) fc.(FC_frame).(f_inst)) fc.(FC_post)), lcs) :: ccs', (vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by eapply r_local_set with (vd := v). 
-      + (* false *)
-        resolve_invalid_typing.
+      (* false *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         erewrite inst_t_context_local_empty in Hconjr; eauto.
         by discriminate_size.
 
-    - (* AI_basic (BI_local_tee j) *)
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_local_tee j) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       (* v :: ves' *)
-      apply <<hs, (s, ccs, (v :: v :: vs0, es0), Some (AI_basic (BI_local_set j)))>> => /=.
+      apply <<hs, (s, (fc, lcs) :: ccs', (v :: v :: vs0, es0), Some (AI_basic (BI_local_set j)))>> => //=.
       resolve_reduce_ctx vs0 es0.
       by eapply r_simple, rs_local_tee.
 
-    - (* AI_basic (BI_global_get j) *)
-      get_cc ccs.
-      destruct (sglob_val s fc.(FC_frame).(f_inst) j) as [v|] eqn:Hsglob.
-      + (* Some xx *)
-        apply <<hs, (s, (fc, lcs) :: ccs', (v :: vs0, es0), None)>>.
+    (* AI_basic (BI_global_get j) *)
+    - destruct (sglob_val s fc.(FC_frame).(f_inst) j) as [v|] eqn:Hsglob.
+      (* Some xx *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (v :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_global_get.
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         * by inst_typing_lookup; remove_bools_options.
         * eapply inst_typing_global_lookup_inv in Hoption as [? [? Hnthg]]; eauto.
           by simplify_multieq.
 
-    - (* AI_basic (BI_global_set j) *)
-      get_cc ccs.    
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_global_set j) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       (* v :: ves' *)
       destruct (supdate_glob s fc.(FC_frame).(f_inst) j v) as [s'|] eqn:Hsupdate.
-      * (* Some s' *)
-        apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>>.
+      (* Some s' *)
+      + apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by eapply r_global_set; subst.
-      * (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         * by inst_typing_lookup; remove_bools_options.
         * eapply inst_typing_global_lookup_inv in Hconjl0 as [? [? Hnthg]]; eauto.
           by simplify_multieq.
 
-    - (* AI_basic (BI_table_get x) *)
-      get_cc ccs.
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_table_get x) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_i32 v.
       destruct (stab_elem s fc.(FC_frame).(f_inst) x ($nou32 v)) as [tabv|] eqn:Hstab.
-      + (* Some xx *)
-        apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_ref tabv) :: vs0, es0), None)>>.
+      (* Some xx *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_ref tabv) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_table_get_success.
-      + (* None *)
-        (* Note that the stab_elem specification in the opsem matches the spec for typed expressions only -- it produces traps in some untyped scenarios which is undefined in spec. But that is not a problem anyway *)
-        apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+      (* None *)
+      (* Note that the stab_elem specification in the opsem matches the spec for typed expressions only -- it produces traps in some untyped scenarios which is undefined in spec. But that is not a problem anyway *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_table_get_failure.
 
-    - (* AI_basic (BI_table_set x) *)
-      get_cc ccs.
-      destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
+    (* AI_basic (BI_table_set x) *)
+    - destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
       (* v2 needs to be a ref and v1 needs to be a i32 num *)
       assert_value_ref v2.
       assert_i32 v1.
       destruct (stab_update s fc.(FC_frame).(f_inst) x ($nou32 v1) v2) as [s'|] eqn:Hsupdate.
-      + (* Some xx *)
-        apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>>.
+      (* Some xx *)
+      + apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_table_set_success.
-      + (* None *)
-        apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+      (* None *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_table_set_failure.
         
-    - (* AI_basic (BI_table_size x) *)
-      get_cc ccs.
-      destruct (stab s fc.(FC_frame).(f_inst) x) as [tab|] eqn:Hstab.
-      + (* Some xx *)
-        apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_num (VAL_int32 ($u32oz (Z.of_nat (tab_size tab))))) :: vs0, es0), None)>>.
+    (* AI_basic (BI_table_size x) *)
+    - destruct (stab s fc.(FC_frame).(f_inst) x) as [tab|] eqn:Hstab.
+      (* Some xx *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_num (VAL_int32 ($u32oz (Z.of_nat (tab_size tab))))) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by eapply r_table_size; eauto.
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         * inst_typing_lookup.
@@ -1118,52 +1010,49 @@ the condition that all values should live in the operand stack. *)
         * eapply inst_typing_table_lookup_inv in Hconjr as [? [? Hnthtab]]; eauto.
           by simplify_multieq.
 
-    - (* AI_basic (BI_table_grow x) *)
-      get_cc ccs.
-      destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
+    (* AI_basic (BI_table_grow x) *)
+    - destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
       (* Takes an i32 and a reference value *)
       assert_i32 v2.
       assert_value_ref v1.
       destruct (stab_grow s fc.(FC_frame).(f_inst) x ($nou32 v2) v1) as [[s' sz]|] eqn:Hstabgrow.
-      + apply <<hs, (s', (fc, lcs) :: ccs', ((VAL_num (VAL_int32 ($u32oz (Z.of_nat sz)))) :: vs0, es0), None)>>.
+      + apply <<hs, (s', (fc, lcs) :: ccs', ((VAL_num (VAL_int32 ($u32oz (Z.of_nat sz)))) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by eapply r_table_grow_success; eauto.
-      + (* None *)
-        apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_num (VAL_int32 int32_minus_one)) :: vs0, es0), None)>>.
+      (* None *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', ((VAL_num (VAL_int32 int32_minus_one)) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by eapply r_table_grow_failure; eauto.
 
-    - (* AI_basic (BI_table_fill x) *)
-      get_cc ccs.
-      destruct vs0 as [|v3 [|v2 [|v1 vs0]]]; try by no_args.
+    (* AI_basic (BI_table_fill x) *)
+    - destruct vs0 as [|v3 [|v2 [|v1 vs0]]]; try by no_args.
       (* Takes i32; ref; i32 *)
       assert_i32 v3.
       assert_value_ref v2.
       assert_i32 v1.
       destruct (stab s fc.(FC_frame).(f_inst) x) as [tab|] eqn:Hstab.
-      + (* Some xx *)
-        destruct (Z.ltb (Z.of_nat (tab_size tab)) (($zou32 v1) + ($zou32 v3))) eqn:Hbound; move/Z.ltb_spec0 in Hbound.
-        * (* Out of bound *)
-          apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+      (* Some xx *)
+      + destruct (Z.ltb (Z.of_nat (tab_size tab)) (($zou32 v1) + ($zou32 v3))) eqn:Hbound; move/Z.ltb_spec0 in Hbound.
+        (* Out of bound *)
+        * apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
           resolve_reduce_ctx vs0 es0.
           by eapply r_table_fill_bound; eauto; lias.
         * destruct (($zou32 v3) == 0)%Z eqn:Hn0; move/eqP in Hn0; simpl in *; subst.
-          { (* Return *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>>.
+          (* Return *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_table_fill_return; eauto; simpl in *; lias.
           }
-          {
-            (* Step *)
-            apply <<hs, (s, (fc, lcs) :: ccs',
+          (* Step *)
+          { apply <<hs, (s, (fc, lcs) :: ccs',
                           ((VAL_ref v2) :: (VAL_num (VAL_int32 v1)) :: vs0,
                             [::($VN (VAL_int32 ($u32oz (Z.add ($zou32 v1) 1)))); ($V (VAL_ref v2)); ($VN (VAL_int32 ($u32oz (Z.sub ($zou32 v3) 1)))); (AI_basic (BI_table_fill x))] ++ es0),
-                          Some (AI_basic (BI_table_set x)))>>.
+                          Some (AI_basic (BI_table_set x)))>> => //.
             resolve_reduce_ctx vs0 es0; simpl in *.
             by eapply r_table_fill_step; eauto; lias.
           }
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         * inst_typing_lookup.
@@ -1171,60 +1060,58 @@ the condition that all values should live in the operand stack. *)
         * eapply inst_typing_table_lookup_inv in Hconjl0 as [? [? Hnthtab]]; eauto.
           by simplify_multieq.
           
-    - (* AI_basic (BI_table_copy x y) *)
-      get_cc ccs.
-      destruct vs0 as [|n [|src [|dst vs0]]]; try by no_args.
+    (* AI_basic (BI_table_copy x y) *)
+    - destruct vs0 as [|n [|src [|dst vs0]]]; try by no_args.
       (* Takes i32; i32; i32 *)
       assert_i32 n.
       assert_i32 src.
       assert_i32 dst.
       destruct (stab s fc.(FC_frame).(f_inst) x) as [tabx|] eqn:Hstabx.
-      + (* Some xx *)
-        destruct (stab s fc.(FC_frame).(f_inst) y) as [taby|] eqn:Hstaby.
-        * (* Some xx *)
-          destruct (Z.ltb (Z.of_nat (tab_size taby)) (($zou32 src) + ($zou32 n))) eqn:Hboundy; move/Z.ltb_spec0 in Hboundy.
-          { (* taby Out of bound *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+      (* Some xx *)
+      + destruct (stab s fc.(FC_frame).(f_inst) y) as [taby|] eqn:Hstaby.
+        (* Some xx *)
+        * destruct (Z.ltb (Z.of_nat (tab_size taby)) (($zou32 src) + ($zou32 n))) eqn:Hboundy; move/Z.ltb_spec0 in Hboundy.
+          (* taby Out of bound *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_table_copy_bound; eauto; lias.
           }
           destruct (Z.ltb (Z.of_nat (tab_size tabx)) (($zou32 dst) + ($zou32 n))) eqn:Hboundx; move/Z.ltb_spec0 in Hboundx.
-          { (* tabx Out of bound *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+          (* tabx Out of bound *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_table_copy_bound; eauto; lias.
           }
-          {
-            (* In bound for both tables *)
-            destruct (($zou32 n) == 0)%Z eqn:Hn0; move/eqP in Hn0; simpl in *; subst.
-            { (* Return *)
-              apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>>.
+          (* In bound for both tables *)
+          { destruct (($zou32 n) == 0)%Z eqn:Hn0; move/eqP in Hn0; simpl in *; subst.
+            (* Return *)
+            { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
               resolve_reduce_ctx vs0 es0.
               by eapply r_table_copy_return; eauto; simpl in *; lias.
             }
             destruct (Z.leb ($zou32 dst) ($zou32 src)) eqn:Hdir; move/Z.leb_spec0 in Hdir.
-            { (* copy -- forward *)
-              apply <<hs, (s, (fc, lcs) :: ccs',
+            (* copy -- forward *)
+            { apply <<hs, (s, (fc, lcs) :: ccs',
                             ((VAL_num (VAL_int32 src)) :: (VAL_num (VAL_int32 dst)) :: vs0,
                               [::(AI_basic (BI_table_set x)); $VN (VAL_int32 ($u32oz (Z.add ($zou32 dst) 1))); $VN (VAL_int32 ($u32oz (Z.add ($zou32 src) 1))); $VN (VAL_int32 ($u32oz (Z.sub ($zou32 n) 1))); AI_basic (BI_table_copy x y)] ++ es0),
-                            Some (AI_basic (BI_table_get y)))>>.
+                            Some (AI_basic (BI_table_get y)))>> => //.
               resolve_reduce_ctx vs0 es0.
               by eapply r_table_copy_forward; eauto; simpl in *; lias.
             }
-            { (* copy -- backward *)
-              apply <<hs, (s, (fc, lcs) :: ccs',
+            (* copy -- backward *)
+            { apply <<hs, (s, (fc, lcs) :: ccs',
                             ((VAL_num (VAL_int32 ($u32oz (Z.sub (Z.add ($zou32 src) ($zou32 n)) 1)))) ::
                             (VAL_num (VAL_int32 ($u32oz (Z.sub (Z.add ($zou32 dst) ($zou32 n)) 1)))) ::
                             vs0,
                               [::(AI_basic (BI_table_set x)); $VN (VAL_int32 dst); $VN (VAL_int32 src); $VN (VAL_int32 ($u32oz (Z.sub ($zou32 n) 1))); AI_basic (BI_table_copy x y)] ++ es0),
-                            Some (AI_basic (BI_table_get y)))>>.
+                            Some (AI_basic (BI_table_get y)))>> => //.
               resolve_reduce_ctx vs0 es0.
               eapply r_table_copy_backward; eauto; simpl in *; try by lias.
             }
           }
 
-        * (* staby = None *)
-          resolve_invalid_typing.
+        (* staby = None *)
+        * resolve_invalid_typing.
           unfold_frame_type Hftype.
           unfold_store_operations.
           {  inst_typing_lookup.
@@ -1234,8 +1121,8 @@ the condition that all values should live in the operand stack. *)
             by simplify_multieq.
           }
           
-      + (* stabx = None *)
-        resolve_invalid_typing.
+      (* stabx = None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         {  inst_typing_lookup.
@@ -1245,53 +1132,51 @@ the condition that all values should live in the operand stack. *)
           by simplify_multieq.
         }
         
-    - (* AI_basic (BI_table_init x y) *)
-      get_cc ccs.
-      destruct vs0 as [|n [|src [|dst vs0]]]; try by no_args.
+    (* AI_basic (BI_table_init x y) *)
+    - destruct vs0 as [|n [|src [|dst vs0]]]; try by no_args.
       (* Takes i32; i32; i32 *)
       assert_i32 n.
       assert_i32 src.
       assert_i32 dst.
       destruct (stab s fc.(FC_frame).(f_inst) x) as [tab|] eqn:Hstab.
-      + (* Some xx *)
-        destruct (selem s fc.(FC_frame).(f_inst) y) as [elem|] eqn:Hselem.
-        * (* Some xx *)
-          destruct (Z.ltb (Z.of_nat (elem_size elem)) (($zou32 src) + ($zou32 n))) eqn:Hboundy; move/Z.ltb_spec0 in Hboundy.
-          { (* elem Out of bound *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+      (* Some xx *)
+      + destruct (selem s fc.(FC_frame).(f_inst) y) as [elem|] eqn:Hselem.
+        (* Some xx *)
+        * destruct (Z.ltb (Z.of_nat (elem_size elem)) (($zou32 src) + ($zou32 n))) eqn:Hboundy; move/Z.ltb_spec0 in Hboundy.
+          (* elem Out of bound *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_table_init_bound; eauto; lias.
           }
           destruct (Z.ltb (Z.of_nat (tab_size tab)) (($zou32 dst) + ($zou32 n))) eqn:Hboundx; move/Z.ltb_spec0 in Hboundx.
-          { (* tab Out of bound *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+          (* tab Out of bound *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_table_init_bound; eauto; lias.
           }
-          {
-            (* In bound for both table and elem *)
-            destruct (($zou32 n) == 0)%Z eqn:Hn0; move/eqP in Hn0; simpl in *; subst.
-            { (* Return *)
-              apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>>.
+          (* In bound for both table and elem *)
+          { destruct (($zou32 n) == 0)%Z eqn:Hn0; move/eqP in Hn0; simpl in *; subst.
+            (* Return *)
+            { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
               resolve_reduce_ctx vs0 es0.
               by eapply r_table_init_return; eauto; simpl in *; lias.
             }
-            { (* Step -- but need to lookup first *)
-              destruct (lookup_N elem.(eleminst_elem) ($nou32 src)) as [v | ] eqn:Hnthelem.
-              { (* Step *)
-                apply <<hs, (s, (fc, lcs) :: ccs',
+            (* Step -- but need to lookup first *)
+            { destruct (lookup_N elem.(eleminst_elem) ($nou32 src)) as [v | ] eqn:Hnthelem.
+              (* Step *)
+              { apply <<hs, (s, (fc, lcs) :: ccs',
                               ((VAL_ref v) :: (VAL_num (VAL_int32 dst)) :: vs0,
                                 [::$VN (VAL_int32 ($u32oz (Z.add ($zou32 dst) 1)));
                                  $VN (VAL_int32 ($u32oz (Z.add ($zou32 src) 1)));
                                  $VN (VAL_int32 ($u32oz (Z.sub ($zou32 n) 1)));
                                  AI_basic (BI_table_init x y)
                                 ] ++ es0),
-                              Some (AI_basic (BI_table_set x)))>>.
+                              Some (AI_basic (BI_table_set x)))>> => //.
                 resolve_reduce_ctx vs0 es0.
                 by eapply r_table_init_step; eauto; simpl in *; lias.
               }
-              { (* lookup oob *)
-                resolve_invalid_typing.
+              (* lookup oob *)
+              { resolve_invalid_typing.
                 destruct elem; unfold elem_size in Hboundy; simpl in *.
                 unfold lookup_N in *; apply List.nth_error_None in Hnthelem.
                 apply Hboundy.
@@ -1312,13 +1197,13 @@ the condition that all values should live in the operand stack. *)
             }
           }
 
-        * (* selem = None *)
-          resolve_invalid_typing.
+        (* selem = None *)
+        * resolve_invalid_typing.
           unfold_frame_type Hftype.
           unfold_store_operations; eapply inst_typing_elem_lookup_inv in Hconjr as [? [? [? [??]]]]; eauto; by simplify_multieq.
           
-      + (* stab = None *)
-        resolve_invalid_typing.
+      (* stab = None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         {  inst_typing_lookup.
@@ -1328,10 +1213,9 @@ the condition that all values should live in the operand stack. *)
           by simplify_multieq.
         }
         
-    - (* AI_basic BI_elem_drop x *)
-      get_cc ccs.
-      destruct (selem_drop s fc.(FC_frame).(f_inst) x) as [s'|] eqn:Hs'.
-      + apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>>.
+    (* AI_basic BI_elem_drop x *)
+    - destruct (selem_drop s fc.(FC_frame).(f_inst) x) as [s'|] eqn:Hs'.
+      + apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_elem_drop.
       + resolve_invalid_typing.
@@ -1344,36 +1228,35 @@ the condition that all values should live in the operand stack. *)
           by simplify_multieq.
         }
 
-    - (* AI_basic (BI_load t ops (Some (tp, sx)) a off) *)
-      get_cc ccs.    
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_load t ops (Some (tp, sx)) a off) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_i32 v.
       (* VAL_int32 v :: ves' *)
       destruct (smem s fc.(FC_frame).(f_inst)) as [mem_s_j|] eqn:?.
-      { (* Some mem_s_j *)
-        destruct ops as [[tp sx] | ].
+      (* Some mem_s_j *)
+      { destruct ops as [[tp sx] | ].
         (* Some (tp, sx) *)
         - destruct (load_packed sx (mem_s_j) ($nou32 v) off (tp_length tp) (tnum_length t)) as [bs|] eqn:Hload.
-          + (* Some bs *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (wasm_deserialise bs t) :: vs0, es0), None)>>.
+          (* Some bs *)
+          + apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (wasm_deserialise bs t) :: vs0, es0), None)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_load_packed_success; subst; eauto.
-          + (* None *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+          (* None *)
+          + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_load_packed_failure; subst; eauto.
         - destruct (load (mem_s_j) ($nou32 v) off (tnum_length t)) as [bs|] eqn:Hload.
-          + (* Some bs *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (wasm_deserialise bs t) :: vs0, es0), None)>>.
+          (* Some bs *)
+          + apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (wasm_deserialise bs t) :: vs0, es0), None)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_load_success; subst; eauto.
-          + (* None *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+          (* None *)
+          + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_load_failure; subst; eauto.
       }
-      { (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      { resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         { inst_typing_lookup; by remove_bools_options. }
@@ -1382,41 +1265,39 @@ the condition that all values should live in the operand stack. *)
         }
       }
 
-    - (* AI_basic (BI_store t (Some tp) a off) *)
-      get_cc ccs. 
-      destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
+    (* AI_basic (BI_store t (Some tp) a off) *)
+    - destruct vs0 as [|v2 [|v1 vs0]]; try by no_args.
       assert_i32 v1.
       assert_value_num v2.
       destruct (typeof_num v2 == t) eqn:Heq; move/eqP in Heq; last by discriminate_value_type; apply num_subtyping in H; inversion H; subst.
       destruct op as [tp | ].
       (* packed *)
       + destruct (smem_store_packed s fc.(FC_frame).(f_inst) ($nou32 v1) off v2 tp) as [s' | ] eqn:Hsmem.
-        * apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>>.
+        * apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
           resolve_reduce_ctx vs0 es0.
           by eapply r_store_packed_success; subst; eauto.
-        * (* None *)
-          apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+        (* None *)
+        * apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
           resolve_reduce_ctx vs0 es0.
           by eapply r_store_packed_failure; subst; eauto.
       (* None *)
       + destruct (smem_store s fc.(FC_frame).(f_inst) ($nou32 v1) off v2 t) as [s' | ] eqn:Hsmem.
-        * apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>>.
+        * apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
           resolve_reduce_ctx vs0 es0.
           by eapply r_store_success; subst; eauto.
-        * (* None *)
-          apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+        (* None *)
+        * apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
           resolve_reduce_ctx vs0 es0.
           by eapply r_store_failure; subst; eauto.
           
-    - (* AI_basic BI_memory_size *)
-      get_cc ccs.    
-      destruct (smem s fc.(FC_frame).(f_inst)) as [s_mem_s_j|] eqn:?.
-      + (* Some j *)
-        apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 ($u32oz (Z.of_N (mem_size (s_mem_s_j))))) :: vs0, es0), None)>>.
+    (* AI_basic BI_memory_size *)
+    - destruct (smem s fc.(FC_frame).(f_inst)) as [s_mem_s_j|] eqn:?.
+      (* Some j *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 ($u32oz (Z.of_N (mem_size (s_mem_s_j))))) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by subst; eapply r_memory_size; eauto.
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         { eapply inst_typing_mem_lookup_inv in Hconjr as [? [Hextmt ?]]; eauto.
@@ -1427,54 +1308,52 @@ the condition that all values should live in the operand stack. *)
           by simplify_multieq.
         }
 
-    - (* AI_basic BI_memory_grow *)
-      get_cc ccs.
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic BI_memory_grow *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_i32 v.
       destruct (smem_grow s fc.(FC_frame).(f_inst) ($nou32 v)) as [[s' sz] | ] eqn:Hsmem.
-      + (* Some mem'' *)
-        apply <<hs, (s', (fc, lcs) :: ccs', (VAL_num (VAL_int32 ($u32oz (Z.of_N sz))) :: vs0, es0), None)>>.
+      (* Some mem'' *)
+      + apply <<hs, (s', (fc, lcs) :: ccs', (VAL_num (VAL_int32 ($u32oz (Z.of_N sz))) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by subst; eapply r_memory_grow_success; eauto.
-      + (* None *)
-        apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 int32_minus_one) :: vs0, es0), None)>>.
+      (* None *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 int32_minus_one) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by subst; eapply r_memory_grow_failure; eauto.
 
-    - (* AI_basic BI_memory_fill *)
-      get_cc ccs.
-      destruct vs0 as [|v3 [|v2 [|v1 vs0]]]; try by no_args.
+    (* AI_basic BI_memory_fill *)
+    - destruct vs0 as [|v3 [|v2 [|v1 vs0]]]; try by no_args.
       (* Takes i32; i32; i32 *)
       assert_i32 v3.
       assert_i32 v2.
       assert_i32 v1.
       destruct (smem s fc.(FC_frame).(f_inst)) as [mem|] eqn:Hsmem.
-      + (* Some *)
-        destruct (Z.ltb (Z.of_nat (mem_length mem)) (Z.add ($zou32 v1) ($zou32 v3))) eqn:Hlt; move/Z.ltb_spec0 in Hlt.
-        * (* true *)
-          apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+      (* Some *)
+      + destruct (Z.ltb (Z.of_nat (mem_length mem)) (Z.add ($zou32 v1) ($zou32 v3))) eqn:Hlt; move/Z.ltb_spec0 in Hlt.
+        (* true *)
+        * apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
           resolve_reduce_ctx vs0 es0.
           by eapply r_memory_fill_bound; eauto; lias.
-        * (* false *)
-          destruct (($zou32 v3) == 0)%Z eqn:Heq0; move/eqP in Heq0.
-          { (* Return *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>>.
+        (* false *)
+        * destruct (($zou32 v3) == 0)%Z eqn:Heq0; move/eqP in Heq0.
+          (* Return *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_memory_fill_return; eauto; lias.
           }
-          { (* Step *)
-            apply <<hs, (s, (fc, lcs) :: ccs',
+          (* Step *)
+          { apply <<hs, (s, (fc, lcs) :: ccs',
                           ((VAL_num (VAL_int32 v2)) :: (VAL_num (VAL_int32 v1)) :: vs0,
                             [::$VN (VAL_int32 ($u32oz (Z.add ($zou32 v1) 1)));
                              $VN (VAL_int32 v2);
                              $VN (VAL_int32 ($u32oz (Z.sub ($zou32 v3) 1)));
                             AI_basic (BI_memory_fill)] ++ es0),
-                          Some (AI_basic (BI_store T_i32 (Some Tp_i8) 0%N 0%N)))>>.
+                          Some (AI_basic (BI_store T_i32 (Some Tp_i8) 0%N 0%N)))>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_memory_fill_step; eauto; lias.
           }
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         { eapply inst_typing_mem_lookup_inv in Hconjr as [? [Hextmt ?]]; eauto.
@@ -1485,57 +1364,55 @@ the condition that all values should live in the operand stack. *)
           by simplify_multieq.
         }
         
-    - (* AI_basic BI_memory_copy *)
-      get_cc ccs.
-      destruct vs0 as [|n [|src [|dst vs0]]]; try by no_args.
+    (* AI_basic BI_memory_copy *)
+    - destruct vs0 as [|n [|src [|dst vs0]]]; try by no_args.
       (* Takes i32; i32; i32 *)
       assert_i32 n.
       assert_i32 src.
       assert_i32 dst.
       destruct (smem s fc.(FC_frame).(f_inst)) as [mem|] eqn:Hsmem.
-      + (* Some *)
-        destruct (Z.ltb (Z.of_nat (mem_length mem)) (($zou32 src) + ($zou32 n))) eqn:Hboundy; move/Z.ltb_spec0 in Hboundy.
-        { (* y Out of bound *)
-          apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+      (* Some *)
+      + destruct (Z.ltb (Z.of_nat (mem_length mem)) (($zou32 src) + ($zou32 n))) eqn:Hboundy; move/Z.ltb_spec0 in Hboundy.
+        (* y Out of bound *)
+        { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
           resolve_reduce_ctx vs0 es0.
           by eapply r_memory_copy_bound; eauto; lias.
         }
         destruct (Z.ltb (Z.of_nat (mem_length mem)) (($zou32 dst) + ($zou32 n))) eqn:Hboundx; move/Z.ltb_spec0 in Hboundx.
-        { (* x Out of bound *)
-          apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+        (* x Out of bound *)
+        { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
           resolve_reduce_ctx vs0 es0.
           by eapply r_memory_copy_bound; eauto; lias.
         }
-        {
-          (* In bound for both memories *)
-          destruct (($zou32 n) == 0)%Z eqn:Hn0; move/eqP in Hn0; simpl in *; subst.
-          { (* Return *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>>.
+        (* In bound for both memories *)
+        { destruct (($zou32 n) == 0)%Z eqn:Hn0; move/eqP in Hn0; simpl in *; subst.
+          (* Return *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_memory_copy_return; eauto; simpl in *; lias.
           }
           destruct (Z.leb ($zou32 dst) ($zou32 src)) eqn:Hdir; move/Z.leb_spec0 in Hdir.
-          { (* copy -- forward *)
-            apply <<hs, (s, (fc, lcs) :: ccs',
+          (* copy -- forward *)
+          { apply <<hs, (s, (fc, lcs) :: ccs',
                           ((VAL_num (VAL_int32 src)) :: (VAL_num (VAL_int32 dst)) :: vs0,
                             [::(AI_basic (BI_store T_i32 (Some Tp_i8) 0%N 0%N)); $VN (VAL_int32 ($u32oz (Z.add ($zou32 dst) 1))); $VN (VAL_int32 ($u32oz (Z.add ($zou32 src) 1))); $VN (VAL_int32 ($u32oz (Z.sub ($zou32 n) 1))); AI_basic (BI_memory_copy)] ++ es0),
-                          Some (AI_basic (BI_load T_i32 (Some (Tp_i8, SX_U)) 0%N 0%N)))>>.
+                          Some (AI_basic (BI_load T_i32 (Some (Tp_i8, SX_U)) 0%N 0%N)))>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_memory_copy_forward; eauto; simpl in *; lias.
           }
-          { (* copy -- backward *)
-            apply <<hs, (s, (fc, lcs) :: ccs',
+          (* copy -- backward *)
+          { apply <<hs, (s, (fc, lcs) :: ccs',
                           ((VAL_num (VAL_int32 ($u32oz (Z.add ($zou32 src) (Z.sub ($zou32 n) 1))))) ::
                              (VAL_num (VAL_int32 ($u32oz (Z.add ($zou32 dst) (Z.sub ($zou32 n) 1))))) ::
                              vs0,
                             [::(AI_basic (BI_store T_i32 (Some Tp_i8) 0%N 0%N)); $VN (VAL_int32 dst); $VN (VAL_int32 src); $VN (VAL_int32 ($u32oz (Z.sub ($zou32 n) 1))); AI_basic (BI_memory_copy)] ++ es0),
-                          Some (AI_basic (BI_load T_i32 (Some (Tp_i8, SX_U)) 0%N 0%N)))>>.
+                          Some (AI_basic (BI_load T_i32 (Some (Tp_i8, SX_U)) 0%N 0%N)))>> => //.
             resolve_reduce_ctx vs0 es0.
             eapply r_memory_copy_backward; eauto; simpl in *; try by lias.
           }
         }
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         { eapply inst_typing_mem_lookup_inv in Hconjr as [? [Hextmt ?]]; eauto.
@@ -1546,53 +1423,51 @@ the condition that all values should live in the operand stack. *)
           by simplify_multieq.
         }
         
-    - (* AI_basic BI_memory_init *)
-      get_cc ccs.
-      destruct vs0 as [|n [|src [|dst vs0]]]; try by no_args.
+    (* AI_basic BI_memory_init *)
+    - destruct vs0 as [|n [|src [|dst vs0]]]; try by no_args.
       (* Takes i32; i32; i32 *)
       assert_i32 n.
       assert_i32 src.
       assert_i32 dst.
       destruct (smem s fc.(FC_frame).(f_inst)) as [mem|] eqn:Hsmem.
-      + (* Some *)
-        destruct (sdata s fc.(FC_frame).(f_inst) x) as [data|] eqn:Hsdata.
-        * (* Some *)
-          destruct (Z.ltb (Z.of_nat (data_size data)) (($zou32 src) + ($zou32 n))) eqn:Hboundy; move/Z.ltb_spec0 in Hboundy.
-          { (* y Out of bound *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+      (* Some *)
+      + destruct (sdata s fc.(FC_frame).(f_inst) x) as [data|] eqn:Hsdata.
+        (* Some *)
+        * destruct (Z.ltb (Z.of_nat (data_size data)) (($zou32 src) + ($zou32 n))) eqn:Hboundy; move/Z.ltb_spec0 in Hboundy.
+          (* y Out of bound *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_memory_init_bound; eauto; lias.
           }
           destruct (Z.ltb (Z.of_nat (mem_length mem)) (($zou32 dst) + ($zou32 n))) eqn:Hboundx; move/Z.ltb_spec0 in Hboundx.
-          { (* x Out of bound *)
-            apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+          (* x Out of bound *)
+          { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
             resolve_reduce_ctx vs0 es0.
             by eapply r_memory_init_bound; eauto; lias.
           }
-          {
-            (* In bound for both table and elem *)
-            destruct (($zou32 n) == 0)%Z eqn:Hn0; move/eqP in Hn0; simpl in *; subst.
-            { (* Return *)
-              apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>>.
+          (* In bound for both table and elem *)
+          { destruct (($zou32 n) == 0)%Z eqn:Hn0; move/eqP in Hn0; simpl in *; subst.
+            (* Return *)
+            { apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
               resolve_reduce_ctx vs0 es0.
               by eapply r_memory_init_return; eauto; simpl in *; lias.
             }
-            { (* Step -- but need to lookup first *)
-              destruct (lookup_N data.(datainst_data) ($nou32 src)) as [b | ] eqn:Hnthdata.
-              { (* Step *)
-                apply <<hs, (s, (fc, lcs) :: ccs',
+            (* Step -- but need to lookup first *)
+            { destruct (lookup_N data.(datainst_data) ($nou32 src)) as [b | ] eqn:Hnthdata.
+              (* Step *)
+              { apply <<hs, (s, (fc, lcs) :: ccs',
                               ((VAL_num (wasm_deserialise [::b] T_i32)) :: (VAL_num (VAL_int32 dst)) :: vs0,
                                 [::$VN (VAL_int32 ($u32oz (Z.add ($zou32 dst) 1)));
                                  $VN (VAL_int32 ($u32oz (Z.add ($zou32 src) 1)));
                                  $VN (VAL_int32 ($u32oz (Z.sub ($zou32 n) 1)));
                                  AI_basic (BI_memory_init x)
                                 ] ++ es0),
-                              Some (AI_basic (BI_store T_i32 (Some Tp_i8) 0%N 0%N)))>>.
+                              Some (AI_basic (BI_store T_i32 (Some Tp_i8) 0%N 0%N)))>> => //.
                 resolve_reduce_ctx vs0 es0.
                 by eapply r_memory_init_step; eauto; simpl in *; lias.
               }
-              { (* lookup oob *)
-                resolve_invalid_typing.
+              (* lookup oob *)
+              { resolve_invalid_typing.
                 destruct data; unfold data_size in Hboundy; simpl in *.
                 unfold lookup_N in *; apply List.nth_error_None in Hnthdata.
                 apply Hboundy.
@@ -1613,8 +1488,8 @@ the condition that all values should live in the operand stack. *)
             }
           }
 
-        * (* sdata = None *)
-          resolve_invalid_typing.
+        (* sdata = None *)
+        * resolve_invalid_typing.
           unfold_frame_type Hftype.
           unfold_store_operations.
           { eapply inst_typing_data_lookup_inv in Hconjr0 as [? [? [? [??]]]]; eauto.
@@ -1624,8 +1499,8 @@ the condition that all values should live in the operand stack. *)
             by simplify_multieq.
           }
 
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         unfold_store_operations.
         { eapply inst_typing_mem_lookup_inv in Hconjl0 as [? [Hextmt ?]]; eauto.
@@ -1636,10 +1511,9 @@ the condition that all values should live in the operand stack. *)
           by simplify_multieq.
         }
           
-    - (* AI_basic BI_data_drop x *)
-      get_cc ccs.
-      destruct (sdata_drop s fc.(FC_frame).(f_inst) x) as [s'|] eqn:Hs'.
-      + apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>>.
+    (* AI_basic BI_data_drop x *)
+    - destruct (sdata_drop s fc.(FC_frame).(f_inst) x) as [s'|] eqn:Hs'.
+      + apply <<hs, (s', (fc, lcs) :: ccs', (vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_data_drop.
       + resolve_invalid_typing.
@@ -1652,24 +1526,23 @@ the condition that all values should live in the operand stack. *)
           by simplify_multieq.
         }
 
-    - (* AI_basic BI_nop *)
-      apply <<hs, (s, ccs, (vs0, es0), None)>> => /=.
+    (* AI_basic BI_nop *)
+    - apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>> => //=.
       resolve_reduce_ctx vs0 es0.
       by apply r_simple, rs_nop.
 
-    - (* AI_basic BI_unreachable *)
-      apply <<hs, (s, ccs, (vs0, es0), Some AI_trap)>> => /=.
+    (* AI_basic BI_unreachable *)
+    - apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //=.
       resolve_reduce_ctx vs0 es0.
       by apply r_simple, rs_unreachable.
 
-    - (* AI_basic (BI_block bt es) *)
-      get_cc ccs.
-      destruct (expand fc.(FC_frame).(f_inst) bt) as [[t1s t2s] | ] eqn:Hexpand.
-      + (* Some t1s t2s *)
-        destruct (length vs0 >= length t1s) eqn:Hlen.
-        * (* true *)
-          destruct (split_n vs0 (length t1s)) as [ves' ves''] eqn:Hsplit.
-          apply <<hs, (s, (fc, lcs) :: ccs', (ves'', es0), Some (AI_label (length t2s) nil (vs_to_es ves' ++ to_e_list es)))>>.
+    (* AI_basic (BI_block bt es) *)
+    - destruct (expand fc.(FC_frame).(f_inst) bt) as [[t1s t2s] | ] eqn:Hexpand.
+      (* Some t1s t2s *)
+      + destruct (length vs0 >= length t1s) eqn:Hlen.
+        (* true *)
+        * destruct (split_n vs0 (length t1s)) as [ves' ves''] eqn:Hsplit.
+          apply <<hs, (s, (fc, lcs) :: ccs', (ves'', es0), Some (AI_label (length t2s) nil (vs_to_es ves' ++ to_e_list es)))>> => //.
           rewrite split_n_is_take_drop in Hsplit; injection Hsplit as ??; subst.
           resolve_reduce_ctx ves'' es0.
           resolve_reduce_ctx (drop (length t1s) vs0) es0.
@@ -1684,26 +1557,25 @@ the condition that all values should live in the operand stack. *)
           repeat rewrite length_is_size.
           repeat rewrite length_is_size in Hlen.
           by rewrite size_rev size_takel.
-        * (* false *)
-          resolve_invalid_typing.
+        (* false *)
+        * resolve_invalid_typing.
           unfold_frame_type Hftype.
           erewrite <- inst_typing_expand_eq in Hconjl0; eauto. 
           rewrite Hconjl0 in Hexpand; injection Hexpand as <- <-.
           by discriminate_size.
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         erewrite <- inst_typing_expand_eq in Hconjl0; eauto.
         by rewrite Hconjl0 in Hexpand.
 
-    - (* AI_basic (BI_loop bt es) *)
-      get_cc ccs.
-      destruct (expand fc.(FC_frame).(f_inst) bt) as [[t1s t2s] | ] eqn:Hexpand.
-      + (* Some t1s t2s *)
-        destruct (length vs0 >= length t1s) eqn:Hlen.
-        * (* true *)
-          destruct (split_n vs0 (length t1s)) as [ves' ves''] eqn:Hsplit.
-          apply <<hs, (s, (fc, lcs) :: ccs', (ves'', es0), Some (AI_label (length t1s) [::AI_basic (BI_loop bt es)] (vs_to_es ves' ++ to_e_list es)))>>.
+    (* AI_basic (BI_loop bt es) *)
+    - destruct (expand fc.(FC_frame).(f_inst) bt) as [[t1s t2s] | ] eqn:Hexpand.
+      (* Some t1s t2s *)
+      + destruct (length vs0 >= length t1s) eqn:Hlen.
+        (* true *)
+        * destruct (split_n vs0 (length t1s)) as [ves' ves''] eqn:Hsplit.
+          apply <<hs, (s, (fc, lcs) :: ccs', (ves'', es0), Some (AI_label (length t1s) [::AI_basic (BI_loop bt es)] (vs_to_es ves' ++ to_e_list es)))>> => //.
           rewrite split_n_is_take_drop in Hsplit; injection Hsplit as ??; subst.
           resolve_reduce_ctx ves'' es0.
           resolve_reduce_ctx (drop (length t1s) vs0) es0.
@@ -1718,117 +1590,115 @@ the condition that all values should live in the operand stack. *)
           repeat rewrite length_is_size.
           repeat rewrite length_is_size in Hlen.
           by rewrite size_rev size_takel.
-        * (* false *)
-          resolve_invalid_typing.
+        (* false *)
+        * resolve_invalid_typing.
           unfold_frame_type Hftype.
           erewrite <- inst_typing_expand_eq in Hconjl0; eauto.
           rewrite Hconjl0 in Hexpand; injection Hexpand as <- <-.
           by discriminate_size.
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         erewrite <- inst_typing_expand_eq in Hconjl0; eauto.
         by rewrite Hconjl0 in Hexpand.
         
-    - (* AI_basic (BI_if tb es1 es2) *)
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_if tb es1 es2) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_i32 v.
       destruct (v == Wasm_int.int_zero i32m) eqn:Heq0; move/eqP in Heq0.
-      + (* true *)
-        apply <<hs, (s, ccs, (vs0, es0), Some (AI_basic (BI_block bt es2)))>> => /=.
+      (* true *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_basic (BI_block bt es2)))>> => //=.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple; apply rs_if_false.
-      + (* false *)
-        apply <<hs, (s, ccs, (vs0, es0), Some (AI_basic (BI_block bt es1)))>> => /=.
+      (* false *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_basic (BI_block bt es1)))>> => //=.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple; apply rs_if_true.
 
-    - (* AI_basic (BI_br j) *)
-      by apply run_ctx_br.
+    (* AI_basic (BI_br j) *)
+    - by apply run_ctx_br.
 
-    - (* AI_basic (BI_br_if j) *)
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_br_if j) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_i32 v.
       destruct (v == Wasm_int.int_zero i32m) eqn:Heqc; move/eqP in Heqc.
-      + (* 0 *)
-        apply <<hs, (s, ccs, (vs0, es0), None)>> => /=.
+      (* 0 *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), None)>> => //=.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple; apply rs_br_if_false.
-      + (* not 0 *)
-        apply <<hs, (s, ccs, (vs0, es0), Some (AI_basic (BI_br j)))>> => /=.
+      (* not 0 *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_basic (BI_br j)))>> => //=.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple; apply rs_br_if_true.
 
-    - (* AI_basic (BI_br_table js j) *)
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_br_table js j) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_i32 v.
       destruct (N.ltb ($nou32 v) (N.of_nat (length js))) eqn:Hlen; move/N.ltb_spec0 in Hlen.
-      + (* true *)
-        destruct (lookup_N js ($nou32 v)) as [js_at_k|] eqn: Hnth.
-        * (* Some js_at_k *)
-          apply <<hs, (s, ccs, (vs0, es0), Some (AI_basic (BI_br js_at_k)))>> => /=.
+      (* true *)
+      + destruct (lookup_N js ($nou32 v)) as [js_at_k|] eqn: Hnth.
+        (* Some js_at_k *)
+        * apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_basic (BI_br js_at_k)))>> => //=.
           resolve_reduce_ctx vs0 es0.
           by apply r_simple; subst; apply rs_br_table.
-        * (* None *)
-          unfold lookup_N in Hnth.
+        (* None *)
+        * unfold lookup_N in Hnth.
           apply List.nth_error_None in Hnth.
           by lias.
-      + (* false *)
-        apply <<hs, (s, ccs, (vs0, es0), Some (AI_basic (BI_br j)))>> => /=.
+      (* false *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_basic (BI_br j)))>> => //=.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple; subst; apply rs_br_table_length; lias.
         
-    - (* AI_basic BI_return *)
-      by apply run_ctx_return.
+    (* AI_basic BI_return *)
+    - by apply run_ctx_return.
 
-    - (* AI_basic (BI_call x) *)
-      get_cc ccs.
-      destruct (lookup_N fc.(FC_frame).(f_inst).(inst_funcs) x) as [a|] eqn: Hnth.
-      + (* Some a *)
-        apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_invoke a))>>.
+    (* AI_basic (BI_call x) *)
+    - destruct (lookup_N fc.(FC_frame).(f_inst).(inst_funcs) x) as [a|] eqn: Hnth.
+      (* Some a *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_invoke a))>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_call.
-      + (* None *)
-        resolve_invalid_typing.
+      (* None *)
+      + resolve_invalid_typing.
         unfold_frame_type Hftype.
         eapply inst_typing_func_lookup_inv in Hconjr as [? [??]]; eauto.
         by simplify_multieq.
 
-    - (* AI_basic (BI_call_indirect x y) *)
-      get_cc ccs.
-      destruct vs0 as [|v vs0]; first by no_args.
+    (* AI_basic (BI_call_indirect x y) *)
+    - destruct vs0 as [|v vs0]; first by no_args.
       assert_i32 v.
       destruct (stab_elem s fc.(FC_frame).(f_inst) x ($nou32 v)) as [vref|] eqn:?.
-      + (* Some a *)
-        destruct vref as [t | a | a].
-        * (* ref_null *)
-          apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>>.
+      (* Some a *)
+      + destruct vref as [t | a | a].
+        (* ref_null *)
+        * apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some AI_trap)>> => //.
           resolve_reduce_ctx vs0 es0.
           by eapply r_call_indirect_failure_null_ref; eauto.
-        * (* funcref *)
-          destruct (lookup_N s.(s_funcs) a) as [cl | ] eqn:Hnthcl.
-          -- (* Some *)
-            destruct (lookup_N (inst_types (f_inst (fc.(FC_frame)))) y == Some (cl_type cl)) eqn:Hcl; move/eqP in Hcl.
-            ++ (* true *)
-              apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_invoke a))>>.
+        (* funcref *)
+        * destruct (lookup_N s.(s_funcs) a) as [cl | ] eqn:Hnthcl.
+          (* Some *)
+          -- destruct (lookup_N (inst_types (f_inst (fc.(FC_frame)))) y == Some (cl_type cl)) eqn:Hcl; move/eqP in Hcl.
+            (* true *)
+            ++ apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_invoke a))>> => //.
               resolve_reduce_ctx vs0 es0.
               by eapply r_call_indirect_success; subst; eauto.
-            ++ (* false *)
-              apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_trap))>>.
+            (* false *)
+            ++ apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_trap))>> => //.
               resolve_reduce_ctx vs0 es0.
               by eapply r_call_indirect_failure_mismatch; subst; eauto.
-          -- (* None *)
-            resolve_invalid_typing.
-            unfold_frame_type Hftype.
-            unfold_store_operations.
-            resolve_store_inst_lookup.
-            destruct t1; remove_bools_options; simpl in *.
-            eapply all_projection in Hif1; eauto.
-            unfold value_typing in Hif1; simpl in Hif1.
-            unfold ext_func_typing in Hif1.
-            by remove_bools_options.
-        * (* externref *)
-          resolve_invalid_typing.
+          (* None *)
+          -- resolve_invalid_typing.
+             unfold_frame_type Hftype.
+             unfold_store_operations.
+             resolve_store_inst_lookup.
+             destruct t1; remove_bools_options; simpl in *.
+             eapply all_projection in Hif1; eauto.
+             unfold value_typing in Hif1; simpl in Hif1.
+             unfold ext_func_typing in Hif1.
+             by remove_bools_options.
+        (* externref *)
+        * resolve_invalid_typing.
           unfold_frame_type Hftype.
           unfold_store_operations.
           resolve_store_inst_lookup.
@@ -1838,29 +1708,37 @@ the condition that all values should live in the operand stack. *)
           simplify_multieq.
           apply ref_subtyping in Hif1.
           by rewrite Hconjl1 in Hif1.
-      + (* None *)
-        apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_trap))>>.
+      (* None *)
+      + apply <<hs, (s, (fc, lcs) :: ccs', (vs0, es0), Some (AI_trap))>> => //.
         resolve_reduce_ctx vs0 es0.
         by eapply r_call_indirect_failure_bound; subst.
 
-    - (* AI_trap *)
-      get_cc ccs.
-      destruct ((vs0 == nil) && (es0 == nil)) eqn:Hscnil; move/andP in Hscnil.
+    (* AI_trap *)
+    - destruct ((vs0 == nil) && (es0 == nil)) eqn:Hscnil; move/andP in Hscnil.
       + destruct Hscnil as [Heq1 Heq2]; move/eqP in Heq1; move/eqP in Heq2; subst.
+        (* Checking if this is the last label ctx *)
         destruct lcs as [ | lc lcs'].
-        * destruct fc as [lvs ? ? les].
-          apply <<hs, (s, ccs', (lvs, les), Some AI_trap)>> => /=.
-          resolve_reduce_ctx lvs les.
+        (* If it is, then check if this is the last frame ctx.
+           In the case where this is also true, we terminate. *)
+        * destruct fc as [fvs ? ? fes].
+          destruct ccs' as [ | cc0 ccs']; first by eapply RSC_trap; eauto.
+          (* Otherwise, exit from the innermost frame. *)
+          apply <<hs, (s, cc0 :: ccs', (fvs, fes), Some AI_trap)>> => //=.
+          (* pivot at cc0 *)
+          replace (cc0 :: ccs') with (nil ++ cc0 :: ccs') at 2 => //.
+          rewrite - cat1s.
+          apply reduce_focus_pivot => //=.
+          apply (list_label_ctx_eval).(ctx_reduce) => //.
+          resolve_reduce_ctx fvs fes.
           by apply r_simple, rs_local_trap.
         * destruct lc as [lvs ? ? les].
-          apply <<hs, (s, (fc, lcs') :: ccs', (lvs, les), Some AI_trap)>>.
-          unfold reduce_ctx.
+          apply <<hs, (s, (fc, lcs') :: ccs', (lvs, les), Some AI_trap)>> => //.
           apply reduce_focus => //=.
           apply list_label_ctx_eval.(ctx_reduce) => //=.
           unfold label_ctx_fill => /=.
           resolve_reduce_ctx lvs les.
           by apply r_simple, rs_label_trap.
-      + apply <<hs, (s, (fc, lcs) :: ccs', (nil, nil), Some AI_trap)>>.
+      + apply <<hs, (s, (fc, lcs) :: ccs', (nil, nil), Some AI_trap)>> => //.
         resolve_reduce_ctx lvs les.
         apply r_simple.
         apply rs_trap with (lh := LH_base (rev vs0) es0) => //.
@@ -1871,32 +1749,40 @@ the condition that all values should live in the operand stack. *)
         assert (H: size vs0 = 0); first (by lias); destruct vs0 => //; clear H.
         assert (H: size es0 = 0); first (by lias); by destruct es0.
 
-    - (* AI_ref a *)
-      by apply RSC_invalid => /=; move => [??].
+    (* AI_ref a *)
+    - by apply RSC_invalid => /=; move => [??].
       
-    - (* AI_ref_extern a *)
-      by apply RSC_invalid => /=; move => [??].
+    (* AI_ref_extern a *)
+    - by apply RSC_invalid => /=; move => [??].
        
-    - (* AI_invoke a *)
-      by apply run_ctx_invoke.
+    (* AI_invoke a *)
+    - by apply run_ctx_invoke.
         
-    - (* AI_label ln les es *)
-      by apply RSC_invalid => /=; move => [??].
+    (* AI_label ln les es *)
+    - by apply RSC_invalid => /=; move => [??].
 
-    - (* AI_frame ln lf es *)
-      by apply RSC_invalid => /=; move => [??].
+    (* AI_frame ln lf es *)
+    - by apply RSC_invalid => /=; move => [??].
   }
 Defined.
 
-(* reformation to a valid configuration, if possible.
-   If the cfg is already a value, report that.
- *)
-Definition run_step_cfg_ctx_reform (cfg: cfg_tuple_ctx) : option cfg_tuple_ctx.
+(* reformation to a valid configuration. *)
+Definition run_step_cfg_ctx_reform (cfg: cfg_tuple_ctx) : option cfg_tuple_ctx :=
+  let '(s, ccs, sc, oe) := cfg in
+  match ctx_update ccs sc oe with
+  | Some (ccs', sc', oe') => Some (s, ccs', sc', oe')
+  | None => None
+  end.
+
+Lemma run_step_reform_valid s ccs sc oe :
+  valid_ccs ccs ->
+  run_step_cfg_ctx_reform (s, ccs, sc, oe) <> None.
 Proof.
-  destruct cfg as [[[s ccs] sc] oe].
-  destruct (ctx_update ccs sc oe) as [[[ccs' sc'] oe'] | ] eqn:Hctxupdate; last by exact None.
-  exact (Some (s, ccs', sc', oe')).
-Defined.
+  move => Hvalid Hcontra.
+  unfold run_step_cfg_ctx_reform in Hcontra.
+  destruct (ctx_update ccs sc oe) as [[[ccs' sc'] oe'] | ] eqn:Hupdate => //.
+  by apply ctx_update_none_impl in Hupdate; subst.
+Qed.
 
 Definition run_v_init (s: store_record) (es: list administrative_instruction) : option cfg_tuple_ctx :=
   match ctx_decompose es with
@@ -1904,175 +1790,101 @@ Definition run_v_init (s: store_record) (es: list administrative_instruction) : 
   | None => None
   end.
 
-Definition run_v_init_with_frame (s: store_record) (f: frame) (n: nat) (es: list administrative_instruction) : option cfg_tuple_ctx :=
-  run_v_init s [::AI_frame n f es].
+(* run_v_init with a frame always returns a valid cfg tuple. *)
+Definition run_v_init_with_frame (s: store_record) (f: frame) (es: list administrative_instruction) : { cfg : cfg_tuple_ctx | ctx_to_cfg cfg = Some (s, (f, es)) /\ valid_cfg_ctx cfg }.
+Proof.
+  (* Arity of outermost frame doesn't matter as it gets removed later *)
+  destruct (run_v_init s [::AI_frame 0 f es]) as [ cfg | ] eqn:Hinit.
+  - exists cfg.
+    move: Hinit.
+    rewrite /run_v_init /ctx_decompose ctx_decompose_aux_equation /=.
+    destruct (ctx_decompose_aux _) as [[[??]?]|] eqn:Hdecomp => //.
+    move => [<-].
+    assert (valid_ccs l) as Hvalidccs; first by apply ctx_decompose_valid_ccs_aux in Hdecomp.
+    repeat split => //.
+    { unfold ctx_to_cfg.
+      apply ctx_decompose_fill_aux in Hdecomp.
+      destruct l using last_ind => //; clear IHl.
+      rewrite rev_rcons.
+      destruct x as [[fvs fk ff fes] lcs].
+      simpl in *.
+      rewrite foldl_rcons in Hdecomp; simpl in Hdecomp.
+      unfold vs_to_es in Hdecomp.
+      destruct (rev fvs) as [ | v vs] eqn:Hrevfvs => //; last by destruct v as [?|?|v] => //; destruct v.
+      simpl in *.
+      destruct fes => //.
+      inversion Hdecomp; subst; clear Hdecomp.
+      by rewrite revK.
+    }
+    { by apply ctx_decompose_valid_aux in Hdecomp. }
+  (* Impossible case *)
+  - exfalso.
+    move: Hinit.
+    rewrite /run_v_init /ctx_decompose ctx_decompose_aux_equation /=.
+    destruct (ctx_decompose_aux _) as [[[??]?]|] eqn:Hdecomp => //; by apply ctx_decompose_acc_some in Hdecomp.
+Defined.
 
 Definition hs_cfg_ctx : Type := host_state * cfg_tuple_ctx.
 
 Definition empty_store_record := Build_store_record nil nil nil nil nil nil.
 
-(* TODO: include proofs *)
 Fixpoint run_multi_step_ctx (fuel: nat) (hs: host_state) (cfg: cfg_tuple_ctx) : (option unit) + (list value) :=
   match fuel with
   | 0 => inl None
   | S n =>
       match run_one_step_ctx hs cfg with
-      | RSC_normal hs' cfg' HReduce =>
+      | RSC_normal hs' cfg' Hvalid HReduce =>
           match run_step_cfg_ctx_reform cfg' with
           | Some cfg'' => run_multi_step_ctx n hs' cfg''
           | None => inl None
           end
-      | RSC_value _ _ vs _ _ _ => inr vs
-      | RSC_value_frame _ _ vs _ _ _ _ _ => inr vs
+      | RSC_value _ _ vs _ => inr vs
       | _ => inl None
       end
   end.
 
-(** Auxiliary definition for running arbitrary expressions, not necessarily with a frame within the expression decomposition.
-    Requires knowing about the number of return values beforehand (can be obtained from typing).
-    Note that this function should *never* be used in the extracted code due to the inefficient
+(** Note that this function should *never* be used in the extracted code due to the inefficient
     usage of fuel. It is only used internally during module instantiation.
  **)
 
-Definition run_multi_step_raw (hs: host_state) (fuel: nat) (s: store_record) (f: frame) (arity: nat) (es: list administrative_instruction): (option unit) + (list value) :=
-  match run_v_init_with_frame s f arity es with
-  | Some cfg => run_multi_step_ctx fuel hs cfg
-  | None => inl None
+Definition run_multi_step_raw (hs: host_state) (fuel: nat) (s: store_record) (f: frame) (es: list administrative_instruction): (option unit) + (list value) :=
+  match run_v_init_with_frame s f es with
+  | exist cfg _ => run_multi_step_ctx fuel hs cfg
   end.
-
 
 Section Interp_ctx_progress.
 
-(** A definition to what is considered a 'valid' tuple by the ctx interpreter.
-    This constraint seems restrictive, but in fact all Wasm runtime configuration can be expressed in this form:
-    the runtime configuration tuple (S; F; es) always has a frame F, which can be used to form the frame context
-    [AI_frame n F es] (with the right choice of n).
- **)
-Definition valid_wasm_instr (es: list administrative_instruction) : bool :=
-  match es with
-  | [::AI_frame _ _ _] => true
-  | _ => false
-  end.
-
-(* Due to the representation of the outermost frame in the ctx interpreter, the
-  terminal values are expanded to include an outermost frame  *)
-Definition terminal_form_ctx (es: list administrative_instruction) : bool :=
-  const_list es ||
-  match es with
-  | [:: AI_frame _ _ es'] => const_list es'
-  | [:: AI_trap] => true
-  | _ => false
-  end.
-                    
-Definition valid_init_Some s es:
-  valid_wasm_instr es ->
-  run_v_init s es <> None.
+(* Derive the progress property from the interpreter *)
+Definition t_progress_interp_ctx: forall (hs: host_state) (s: store_record) (f: frame) es ts,
+  config_typing s (f, es) ts ->
+  terminal_form es \/
+    (exists hs' s' f' es', reduce hs s f es hs' s' f' es').
 Proof.
-  move => Hvalid.
-  destruct es as [| e es] => //; destruct e, es => //.
-  rewrite /run_v_init /ctx_decompose ctx_decompose_aux_equation /=.
-  destruct (ctx_decompose_aux _) as [[[??]?]|] eqn:Hdecomp => //; by apply ctx_decompose_acc_some in Hdecomp.
-Qed.
-
-(* The only case where run_v_init produces an invalid cfg is when there is no call context (which is only possible
-   in real Wasm execution at module entrance with a single Invoke *)
-Lemma run_v_init_valid: forall (s: store_record) es,
-    store_typing s ->
-    valid_wasm_instr es ->
-    exists s' ccs sc oe, run_v_init s es = Some (s', ccs, sc, oe) /\ valid_cfg_ctx (s', ccs, sc, oe).
-Proof.
-  move => s es Hstype Hvalid.
-  destruct (run_v_init s es) as [[[[s' ccs] sc] oe]|] eqn:Hinit; last by eapply valid_init_Some in Hvalid; apply Hvalid in Hinit.
-  exists s', ccs, sc, oe; split => //.
-  unfold run_v_init in Hinit.
-  destruct (ctx_decompose es) as [[[ccs' sc'] oe'] | ] eqn:Hdecomp => //; inversion Hinit; subst; clear Hinit.
-  split; last by apply ctx_decompose_valid_split in Hdecomp.
-  unfold ctx_decompose in Hdecomp.
-  destruct es as [| e es'] => //; destruct e, es' => //.
-  rewrite ctx_decompose_aux_equation in Hdecomp; simpl in Hdecomp.
-  by apply ctx_decompose_valid_ccs_aux in Hdecomp.
-Qed.
-
-(* Somewhat subsumed by the lemma below, although this might still be helpful
-in places where typing term is not available *)
-Lemma valid_instr_preserve (hs: host_state) s f es hs' s' f' es':
-  reduce hs s f es hs' s' f' es' ->
-  valid_wasm_instr es ->
-  valid_wasm_instr es' \/ terminal_form_ctx es'.
-Proof.
-  move => Hred.
-  induction Hred => //; subst; move => Hvalid; (try by left); (try by (right; (try by left); (try by right))).
-  (* Simple *)
-  - destruct e as [ | e es] => //; destruct e, es => //.
-    + inversion H; subst; clear H; (try by destruct vs as [ | v vs] => //; destruct vs); (try by right => /=).
-  - by right; unfold terminal_form_ctx; rewrite H4.
-  - by right; unfold terminal_form_ctx; rewrite H3.
-  (* Block *)
-  - by destruct vs as [| v vs] => //; destruct v => //.
-  (* Loop *)
-  - by destruct vs as [| v vs] => //; destruct v => //.
-  (* Host *)
-  - right.
-    destruct r => //=.
-    unfold terminal_form_ctx; by rewrite v_to_e_const.
-  (* Frame *)
-  - destruct lh using lh_case; destruct k => //.
-    + rewrite -> lh_cast_eq in *.
-      simpl in *.
-      destruct vs => //=; last destruct v as [v | v | v] => //=; try by destruct v => //.
-      destruct es as [ | e es]; first by apply reduce_not_nil in Hred.
-      destruct e, es, es0 => //; by apply IHHred in Hvalid; rewrite cats0.
-    + inversion H; subst.
-      rewrite -> lh_cast_eq in *; clear H.
-      simpl in Hvalid.
-      destruct vs as [| v vs] => //; destruct v as [v|v|v] => //=; by destruct v.
-Qed.
-
-(* The induced progress for this version looks slightly weaker, as it only applies to valid instructions directly.
-   However, every function call starts with a valid instruction and continues to be one until the call is exited 
-   (preservation of valid instructions).
-*)
-Definition t_progress_interp_ctx: forall (hs: host_state) (s: store_record) es ts,
-  valid_wasm_instr es ->
-  config_typing s (empty_frame, es) ts ->
-  terminal_form_ctx es \/
-    (exists hs' s' es', reduce hs s empty_frame es hs' s' empty_frame es' /\
-                     valid_wasm_instr es).
-Proof.
-  move => hs s es ts Hvalid Htype.
-  destruct (run_v_init s es) as [[[[s0 ccs] sc] oe]|] eqn:Hinit; last by eapply valid_init_Some in Hvalid; apply Hvalid in Hinit.
-  destruct es as [| e es] => //; destruct e, es => //.
-  (* Frame *)
-  { remember Hinit as Hinit2; clear HeqHinit2.
-    unfold run_v_init in Hinit.
-    rewrite /ctx_decompose ctx_decompose_aux_equation /= in Hinit.
-    destruct (ctx_decompose_aux _) as [[[ccs' sc'] oe'] | ] eqn:Hdecomp => //; injection Hinit as <- -> -> ->.
-    { remember (run_one_step_ctx hs (s, ccs, sc, oe)) as res.
-      destruct res as [hs' [[[s' ccs'] sc'] oe'] Hred | hs0 s0 vs ? ? Heq | hs0 s0 vs n0 f0 ? ? Heq | Hcontra | Hcontra]; clear Heqres.
-      1,2,3,5:
-      unfold run_v_init in Hinit2; destruct (ctx_decompose _) as [[[ccs2 sc2] oe2]|] eqn:Hdecomp' => //;
-      apply ctx_decompose_fill_id in Hdecomp';
-      simpl in Hdecomp';
-      injection Hinit2 as -> -> ->.
-      - right.
-        unfold reduce_ctx in Hred.
-        simpl in *.
-        rewrite Hdecomp' in Hred.
-        repeat eexists. by eauto.
-      - simpl in *.
-        rewrite Hdecomp' in Heq.
-        destruct vs as [ | v vs] => //; destruct v, vs => //; by destruct v.
-      - simpl in *.
-        rewrite Hdecomp' in Heq.
-        injection Heq as -> -> ->.
-        left; unfold terminal_form_ctx; by rewrite v_to_e_const.
-      - simpl in Hcontra. rewrite Hdecomp' in Hcontra. by apply Hcontra in Htype.
-      - exfalso; apply Hcontra; clear Hcontra.
-        split;
-        by [apply ctx_decompose_valid_ccs_aux in Hdecomp
-           | apply ctx_decompose_valid_aux in Hdecomp ].
-    }
-  }
+  move => hs s f es ts Htype.
+  (* initialise an interpreter cfg tuple *)
+  destruct (run_v_init_with_frame s f es) as [[[[s0 ccs] sc] oe] [Hfill Hvalid]].
+  (* run the interpreter *)
+  remember (run_one_step_ctx hs (s0, ccs, sc, oe)) as res.
+  destruct res as [hs' [[[s' ccs'] sc'] oe'] Hred Hvalid' | s' f' vs Hvalfill | s' f' Htrapfill | Hcontra | Hcontra]; clear Heqres.
+  (* step *)
+  - unfold reduce_ctx in Hred.
+    rewrite Hfill in Hred.
+    destruct (ctx_to_cfg (s', ccs', sc', oe')) as [[s'' [f'' es'']] | ] => //.
+    right.
+    by exists hs', s'', f'', es''.
+  (* values *)
+  - rewrite Hvalfill in Hfill; injection Hfill as <- <- <-.
+    do 2 left.
+    by apply v_to_e_const.
+  (* trap *)
+  - rewrite Htrapfill in Hfill; injection Hfill as <- <- <-.
+    by left; right.
+  (* invalid input -- impossible *)
+  - by apply Hcontra in Hvalid.
+  (* ill-typed -- impossible *)
+  - unfold ctx_cfg_typing in Hcontra.
+    rewrite Hfill in Hcontra.
+    by apply Hcontra in Htype.
 Qed.
 
 End Interp_ctx_progress.
@@ -2116,13 +1928,12 @@ Definition run_step_cfg_ctx_reform : cfg_tuple_ctx -> option cfg_tuple_ctx := ru
 
 Definition run_v_init : store_record -> list administrative_instruction -> option cfg_tuple_ctx := run_v_init.
 
-Definition run_v_init_with_frame : store_record -> frame -> nat -> list administrative_instruction -> option cfg_tuple_ctx := run_v_init_with_frame.
+Definition run_v_init_with_frame := run_v_init_with_frame.
 
-Definition run_multi_step_raw : host_state -> nat -> store_record -> frame -> nat -> list administrative_instruction -> (option unit) + (list value) := run_multi_step_raw host_application_impl_correct.
+Definition run_multi_step_raw : host_state -> nat -> store_record -> frame -> list administrative_instruction -> (option unit) + (list value) := run_multi_step_raw host_application_impl_correct.
 
 Definition es_of_cfg : cfg_tuple_ctx -> list administrative_instruction := es_of_cfg.
 
 Definition s_of_cfg : cfg_tuple_ctx -> store_record := s_of_cfg.
 
 End Interpreter_ctx_extract.
-

--- a/theories/interpreter_ctx.v
+++ b/theories/interpreter_ctx.v
@@ -1776,12 +1776,15 @@ Definition run_step_cfg_ctx_reform (cfg: cfg_tuple_ctx) : option cfg_tuple_ctx :
 
 Lemma run_step_reform_valid s ccs sc oe :
   valid_ccs ccs ->
-  run_step_cfg_ctx_reform (s, ccs, sc, oe) <> None.
+  exists cfg, run_step_cfg_ctx_reform (s, ccs, sc, oe) = Some cfg /\
+         valid_cfg_ctx cfg.
 Proof.
-  move => Hvalid Hcontra.
-  unfold run_step_cfg_ctx_reform in Hcontra.
-  destruct (ctx_update ccs sc oe) as [[[ccs' sc'] oe'] | ] eqn:Hupdate => //.
-  by apply ctx_update_none_impl in Hupdate; subst.
+  move => Hvalid.
+  unfold run_step_cfg_ctx_reform.
+  eapply ctx_update_valid_ccs with (sctx := sc) (oe := oe) in Hvalid as [ccs' [sctx' [oe' [Hupdate Hvalid]]]].
+  rewrite Hupdate.
+  eexists; do 2 split => //.
+  by apply ctx_update_valid in Hupdate.
 Qed.
 
 Definition run_v_init (s: store_record) (es: list administrative_instruction) : option cfg_tuple_ctx :=

--- a/theories/pp.v
+++ b/theories/pp.v
@@ -523,16 +523,16 @@ Definition pp_cfg_tuple_ctx_except_store (cfg: cfg_tuple_ctx) : string :=
 
 Definition pp_res_cfg_except_store {hs: host_state} {cfg: cfg_tuple_ctx} (res: run_step_ctx_result hs cfg) : string :=
   match res with
-  | RSC_normal hs' cfg' _ =>
+  | RSC_normal hs' cfg' _ _ =>
       pp_cfg_tuple_ctx_except_store cfg' ++ newline
-  | RSC_value _ _ vs _ _ _ =>
+  | RSC_value _ _ vs _ =>
       "Value:" ++ newline ++ pp_values_hint_empty vs ++ newline
-  | RSC_value_frame _ _ vs _ _ _ _ _ =>
-      "Value:" ++ newline ++ pp_values_hint_empty vs ++ newline
+  | RSC_trap _ _ _ =>
+      "Trap" ++ newline
   | RSC_invalid _ =>
-      "Invalid context. This should not happen when executing a module start function. Please report a bug if this error arises during invocation of module start functions." ++ newline
+      "Invalid context decomposition. This result should not be observed when invoking valid Wasm modules. Please submit a bug report at GitHub/WasmCert-Coq." ++ newline
   | RSC_error _ =>
-      "Ill-typed input configuration"
+      "Ill-typed input configuration. This result should not be observed when invoking valid Wasm modules. Please submit a bug report at GitHub/WasmCert-Coq." ++ newline
   end.
 
 End Host.
@@ -558,4 +558,3 @@ Definition pp_administrative_instructions := pp_administrative_instructions.
 End Show.
 
 End PP.
-

--- a/theories/type_progress.v
+++ b/theories/type_progress.v
@@ -1,0 +1,54 @@
+From Wasm Require Export interpreter_ctx.
+From Coq Require Import ZArith.BinInt Program.Equality.
+From mathcomp Require Import ssreflect ssrfun ssrnat ssrbool eqtype seq.
+Require Import BinNat NArith BinNums ZArith.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+
+Unset Printing Implicit Defensive.
+
+Section Host.
+
+Context `{ho: host}.
+
+(* The same host function well-formedness assumptions from the interpreter *)
+Variable host_application_impl : host_state -> store_record -> function_type -> host_function -> seq value -> (host_state * option (store_record * result)).
+
+Hypothesis host_application_impl_correct :
+  (forall hs s ft hf vs hs' hres, (host_application_impl hs s ft hf vs = (hs', hres)) -> host_application hs s ft hf vs hs' hres).
+
+(* The progress property is derived from the interpreter. *)
+Definition t_progress_interp_ctx: forall (hs: host_state) (s: store_record) (f: frame) es ts,
+  config_typing s (f, es) ts ->
+  terminal_form es \/
+    (exists hs' s' f' es', reduce hs s f es hs' s' f' es').
+Proof.
+  move => hs s f es ts Htype.
+  (* initialise an interpreter cfg tuple *)
+  destruct (run_v_init_with_frame s f es) as [[[[s0 ccs] sc] oe] [Hfill Hvalid]].
+  (* run the interpreter *)
+  remember (@run_one_step_ctx _ _ host_application_impl host_application_impl_correct hs (s0, ccs, sc, oe)) as res.
+  destruct res as [hs' [[[s' ccs'] sc'] oe'] Hred Hvalid' | s' f' vs Hvalfill | s' f' Htrapfill | Hcontra | Hcontra]; clear Heqres.
+  (* step *)
+  - unfold reduce_ctx in Hred.
+    rewrite Hfill in Hred.
+    destruct (ctx_to_cfg (s', ccs', sc', oe')) as [[s'' [f'' es'']] | ] => //.
+    right.
+    by exists hs', s'', f'', es''.
+  (* values *)
+  - rewrite Hvalfill in Hfill; injection Hfill as <- <- <-.
+    do 2 left.
+    by apply v_to_e_const.
+  (* trap *)
+  - rewrite Htrapfill in Hfill; injection Hfill as <- <- <-.
+    by left; right.
+  (* invalid input -- impossible *)
+  - by apply Hcontra in Hvalid.
+  (* ill-typed -- impossible *)
+  - unfold ctx_cfg_typing in Hcontra.
+    rewrite Hfill in Hcontra.
+    by apply Hcontra in Htype.
+Qed.
+
+End Host.

--- a/theories/typing_inversion.v
+++ b/theories/typing_inversion.v
@@ -801,6 +801,36 @@ Proof.
   by remove_bools_options.
 Qed.
 
+Lemma inst_t_context_return_None: forall s i C,
+    inst_typing s i = Some C ->
+    tc_return C = None.
+Proof.
+  move => s i C HInstType.
+  unfold inst_typing, typing.inst_typing in HInstType.
+  destruct i => //=.
+  by remove_bools_options.
+Qed.
+
+Lemma frame_typing_label_empty: forall s f C,
+    frame_typing s f C ->
+    tc_labels C = nil.
+Proof.
+  move => s f C Hftype.
+  unfold frame_typing in Hftype; remove_bools_options.
+  destruct Hftype as [ts [-> Hvt]] => /=.
+  by eapply inst_t_context_label_empty; eauto.
+Qed.
+
+Lemma frame_typing_return_None: forall s f C,
+    frame_typing s f C ->
+    tc_return C = None.
+Proof.
+  move => s f C Hftype.
+  unfold frame_typing in Hftype; remove_bools_options.
+  destruct Hftype as [ts [-> Hvt]] => /=.
+  by eapply inst_t_context_return_None; eauto.
+Qed.
+
 Lemma global_type_reference: forall s i j C v t,
     store_typing s ->
     inst_typing s i = Some C ->

--- a/theories/typing_inversion.v
+++ b/theories/typing_inversion.v
@@ -771,6 +771,8 @@ Ltac invert_e_typing :=
     let Htisub := fresh "Htisub" in
     let Hinvgoal := fresh "Hinvgoal" in
     apply e_typing_inversion in H as [tf_principal [Htisub Hinvgoal]]; simpl in Hinvgoal; extract_premise
+  | H: e_typing _ _ nil _ |- _ =>
+    apply empty_e_typing in H
   | H: e_typing _ _ (cons ?x _) _ |- _ =>
     rewrite -(cat1s x) in H
   end; invert_be_typing; resolve_list_eq.


### PR DESCRIPTION
Properly constructed the original progress statement from the interpreter instead of an (almost) equivalent version of it. Refactored the context interpreter in a cleaner way without using the dummy empty frame.