### PR TITLE
Strengthen numeric opsems to be independent from type system

### DIFF
--- a/changelogs/v2.0.2.md
+++ b/changelogs/v2.0.2.md
@@ -5,6 +5,9 @@ The codebase is now updated to work with Coq 8.20. The other dependencies have a
 
 ## New features
 - Added implementation of the saturating float-to-int instruction.
+- The opsem rules for numeric instructions now require a type checking in addition to the numeric proxy operators (`unop/binop/...`).
+  This type checking is redundant when the type system is enforced. Instead, this change makes the opsem more self-contained as a 
+  standalone definition.
 
 ## Refactorings
 - The subtyping definitions are now refactored into a standalone file `subtyping.v`, relocating from `operations.v`.

--- a/theories/operations.v
+++ b/theories/operations.v
@@ -243,6 +243,26 @@ Definition context_agree (C C': t_context) : bool :=
   (C.(tc_labels) == C'.(tc_labels)) &&
   (C.(tc_return) == C'.(tc_return)).
 
+
+(* Auxiliary definitions for expressing numerics semantics and typing *)
+Definition unop_type_agree (t: number_type) (op: unop): bool :=
+  match op with
+  | Unop_i _ | Unop_extend _ => (t == T_i32) || (t == T_i64)
+  | Unop_f _ => (t == T_f32) || (t == T_f64)
+  end.
+
+Definition binop_type_agree (t: number_type) (op: binop): bool :=
+  match op with
+  | Binop_i _ => (t == T_i32) || (t == T_i64)
+  | Binop_f _ => (t == T_f32) || (t == T_f64)
+  end.
+
+Definition relop_type_agree (t: number_type) (op: relop): bool :=
+  match op with
+  | Relop_i _ => (t == T_i32) || (t == T_i64)
+  | Relop_f _ => (t == T_f32) || (t == T_f64)
+  end.
+
 Definition typeof_num (v : value_num) : number_type :=
   match v with
   | VAL_int32 _ => T_i32
@@ -250,6 +270,16 @@ Definition typeof_num (v : value_num) : number_type :=
   | VAL_float32 _ => T_f32
   | VAL_float64 _ => T_f64
   end.
+
+Definition unop_typecheck (v: value_num) (t: number_type) (op: unop): bool :=
+  (typeof_num v == t) && unop_type_agree t op.
+
+Definition binop_typecheck (v1 v2: value_num) (t: number_type) (op: binop) : bool :=
+  (typeof_num v1 == t) && (typeof_num v2 == t) && binop_type_agree t op.
+
+Definition relop_typecheck (v1 v2: value_num) (t: number_type) (op: relop) : bool :=
+  (typeof_num v1 == t) && (typeof_num v2 == t) && relop_type_agree t op.
+
 
 Definition typeof_vec (v: value_vec) : vector_type :=
   match v with

--- a/theories/opsem.v
+++ b/theories/opsem.v
@@ -18,13 +18,16 @@ Inductive reduce_simple : seq administrative_instruction -> seq administrative_i
 
 (** unop **)
   | rs_unop : forall v op t,
+    unop_typecheck v t op ->
     reduce_simple [::$VN v; AI_basic (BI_unop t op)] [::$VN (@app_unop op v)]
                    
 (** binop **)
   | rs_binop_success : forall v1 v2 v op t,
+    binop_typecheck v1 v2 t op ->
     app_binop op v1 v2 = Some v ->
     reduce_simple [::$VN v1; $VN v2; AI_basic (BI_binop t op)] [::$VN v]
   | rs_binop_failure : forall v1 v2 op t,
+    binop_typecheck v1 v2 t op ->
     app_binop op v1 v2 = None ->
     reduce_simple [::$VN v1; $VN v2; AI_basic (BI_binop t op)] [::AI_trap]
                   
@@ -38,6 +41,7 @@ Inductive reduce_simple : seq administrative_instruction -> seq administrative_i
 
   (** relops **)
   | rs_relop: forall v1 v2 t op,
+    relop_typecheck v1 v2 t op ->
     reduce_simple [::$VN v1; $VN v2; AI_basic (BI_relop t op)] [::$VN (VAL_int32 (wasm_bool (app_relop op v1 v2)))]
                     
   (** cvtop **)

--- a/theories/type_checker.v
+++ b/theories/type_checker.v
@@ -168,40 +168,23 @@ Fixpoint check_single (C : t_context) (ct : option checker_type) (be : basic_ins
           | _ => None
           end
       | BI_unop t op =>
-          match op with
-          | Unop_i _ => if is_int_t t
-                       then type_update ts [::(T_num t)] [::T_num t]
-                       else None
-          | Unop_f _ => if is_float_t t
-                       then type_update ts [::(T_num t)] [::T_num t]
-                       else None
-          | Unop_extend _ =>
-              (* Technically, this needs to check validity of the extend arg; but such instruction can never arise from parsing *)
-              if is_int_t t
-              then type_update ts [::(T_num t)] [::T_num t]
-              else None
+          match unop_type_agree t op with
+          | true => type_update ts [::T_num t] [::T_num t]
+          | false => None
           end
       | BI_binop t op =>
-          match op with
-          | Binop_i _ => if is_int_t t
-                        then type_update ts [::(T_num t); (T_num t)] [::(T_num t)]
-                        else None
-          | Binop_f _ => if is_float_t t
-                        then type_update ts [::(T_num t); (T_num t)] [::(T_num t)]
-                        else None
+          match binop_type_agree t op with
+          | true => type_update ts [::T_num t; T_num t] [::T_num t]
+          | false => None
           end
       | BI_testop t _ =>
           if is_int_t t
           then type_update ts [::(T_num t)] [::(T_num T_i32)]
           else None
       | BI_relop t op =>
-          match op with
-          | Relop_i _ => if is_int_t t
-                        then type_update ts [::(T_num t); (T_num t)] [::(T_num T_i32)]
-                        else None
-          | Relop_f _ => if is_float_t t
-                        then type_update ts [::(T_num t); (T_num t)] [::(T_num T_i32)]
-                        else None
+          match relop_type_agree t op with
+          | true => type_update ts [::T_num t; T_num t] [::T_num T_i32]
+          | false => None
           end
       | BI_cvtop t2 op t1 sx =>
           if cvtop_valid t2 op t1 sx

--- a/theories/type_checker_reflects_typing.v
+++ b/theories/type_checker_reflects_typing.v
@@ -192,12 +192,12 @@ Ltac simplify_tc_goal :=
   | H: ?expr = _ |-
     context [?expr] =>
       rewrite H
-  | H: unop_type_agree ?t ?op |- _ =>
+(*  | H: unop_type_agree ?t ?op = true |- _ =>
       destruct t, op; inversion H; subst; clear H
-  | H: binop_type_agree ?t ?op |- _ =>
+  | H: binop_type_agree ?t ?op = true |- _ =>
       destruct t, op; inversion H; subst; clear H
-  | H: relop_type_agree ?t ?op |- _ =>
-      destruct t, op; inversion H; subst; clear H
+  | H: relop_type_agree ?t ?op = true |- _ =>
+      destruct t, op; inversion H; subst; clear H*)
   | H: lookup_N ?l ?n = ?x
     |- context [lookup_N (map _ ?l) ?n] =>
     rewrite lookup_N_map H
@@ -1230,30 +1230,24 @@ Proof.
       split => //.
       by eapply bet_composition; eauto.
   (* Single *)
-  - destruct e => //=; (try destruct i as [tn' tm']); simplify_tc_goal; move => cts' Hs Hupdate Hagree => //; simplify_tc_goal; invert_update_agree; simplify_tc_goal; try resolve_check_agree; try rewrite rev_cat.
+  - destruct e => //=; (try destruct i as [tn' tm']); simplify_tc_goal;
+                 move => cts' Hs Hupdate Hagree => //; simplify_tc_goal;
+                 invert_update_agree; simplify_tc_goal;
+                 try resolve_check_agree; try rewrite rev_cat.
+    (* It is true that many cases can be automatically resolved. However,
+       we avoid doing so -- so that this proof is easier to be fixed when
+       there's a major update in the future. *)
     (* Const_num *)
     + by resolve_tc_be_typing.
-    (* Unop_i *)
+    (* Unop *)
     + apply bet_weakening, bet_unop.
       destruct n, u => //; by constructor.
-    (* Unop_f *)
-    + apply bet_weakening, bet_unop.
-      destruct n, u => //; by constructor.
-    (* Unop_extend *)
-    + apply bet_weakening, bet_unop.
-      destruct n, n0 => //; by constructor.
-    (* Binop_i *)
-    + apply bet_weakening, bet_binop.
-      destruct n, b => //; by constructor.
-    (* Binop_f *)
+    (* Binop *)
     + apply bet_weakening, bet_binop.
       destruct n, b => //; by constructor.
     (* Testop *)
     + by resolve_tc_be_typing.
-    (* Relop_i *)
-    + apply bet_weakening, bet_relop.
-      destruct n, r => //; by constructor.
-    (* Relop_f *)
+    (* Relop *)
     + apply bet_weakening, bet_relop.
       destruct n, r => //; by constructor.
     (* Cvtop *)

--- a/theories/typing.v
+++ b/theories/typing.v
@@ -180,29 +180,6 @@ Definition upd_label C lab :=
 Definition upd_return C ret :=
   upd_local_label_return C (tc_locals C) (tc_labels C) ret.
 
-Inductive unop_type_agree: number_type -> unop -> Prop :=
-  | Unop_i32_agree: forall op, unop_type_agree T_i32 (Unop_i op)
-  | Unop_i64_agree: forall op, unop_type_agree T_i64 (Unop_i op)
-  | Unop_f32_agree: forall op, unop_type_agree T_f32 (Unop_f op)
-  | Unop_f64_agree: forall op, unop_type_agree T_f64 (Unop_f op)
-  | Unop_extend_agree_i32: forall n, unop_type_agree T_i32 (Unop_extend n)
-  | Unop_extend_agree_i64: forall n, unop_type_agree T_i64 (Unop_extend n)
-  .
-   
-Inductive binop_type_agree: number_type -> binop -> Prop :=
-  | Binop_i32_agree: forall op, binop_type_agree T_i32 (Binop_i op)
-  | Binop_i64_agree: forall op, binop_type_agree T_i64 (Binop_i op)
-  | Binop_f32_agree: forall op, binop_type_agree T_f32 (Binop_f op)
-  | Binop_f64_agree: forall op, binop_type_agree T_f64 (Binop_f op)
-  .
-  
-Inductive relop_type_agree: number_type -> relop -> Prop :=
-  | Relop_i32_agree: forall op, relop_type_agree T_i32 (Relop_i op)
-  | Relop_i64_agree: forall op, relop_type_agree T_i64 (Relop_i op)
-  | Relop_f32_agree: forall op, relop_type_agree T_f32 (Relop_f op)
-  | Relop_f64_agree: forall op, relop_type_agree T_f64 (Relop_f op)
-  .
-
 (* Helper for typing Select. Needs to get an update when updating to GC to implement
    subtyping *)
 Definition is_numeric_type (t: value_type) : bool :=


### PR DESCRIPTION
The old design used for the numeric proxy operations rely on the input being well-typed. Although this is a fine design on its own when the opsem and the type system are considered together, the usability of the opsem itself when treated as a standalone definition is degraded, since ill-typed programs can incorrectly progress. This query was raised in #61 .

This PR adds the required type checks in the opsem for the operation to match the operands.

This is not without cost -- the extracted interpreter now performs an additional redundant type check for numeric instructions. However, running the large benchmarks (e.g. `tests/bigrec.md`) show that the performance were not affected too much -- the numeric operations themselves seem far slower than the type checking added.