### PR TITLE
Update to MathComp 2.x

### DIFF
--- a/changelogs/v2.0.2.md
+++ b/changelogs/v2.0.2.md
@@ -17,9 +17,9 @@ developments that only use the mechanised definitions but not the proofs.
 
 ## Bugfix
 - Fixed a bug where the signatures of the returned values are incorrect for certain float-to-int conversions.
-- Fixed a bug where the binary parser incorrectly parse the order of arguments of the `table.init` instruction (should be reversed) and added a corresponding test.
-- Fixed a bug where the binary parser incorrectly parse the order of memory arguments after a recent incorrect change (should be reversed) and added a corresponding test.
+- Fixed a bug where the binary parser incorrectly parses the order of arguments of the `table.init` instruction (should be reversed) and added a corresponding test.
+- Fixed a bug where the binary parser incorrectly parses the order of memory arguments after a recent incorrect change (should be reversed) and added a corresponding test.
 
-# Feature Improvements
+## Feature Improvements
 - Reworked the parser to be cleaner and significantly more efficient.
 - Improved the error message when an export function with arguments are invoked (currently not supported).

--- a/changelogs/v2.0.3.md
+++ b/changelogs/v2.0.3.md
@@ -1,0 +1,4 @@
+# Release 2.0.3
+
+## Dependency Updates
+- Updating the repository to work with MathComp version 2.x.

--- a/changelogs/v2.0.3.md
+++ b/changelogs/v2.0.3.md
@@ -2,3 +2,6 @@
 
 ## Dependency Updates
 - Updating the repository to work with MathComp version 2.x.
+
+## Miscellaneous
+- The conversion between compcert byte and Coq byte now goes through binary integers instead of nat.

--- a/coq-wasm.opam
+++ b/coq-wasm.opam
@@ -16,7 +16,7 @@ depends: [
   "coq" {>= "8.20" & < "8.21~"}
   "coq-compcert" {>= "3.14"}
   "coq-ext-lib" {>= "0.11.8"}
-  "coq-mathcomp-ssreflect" {< "2.0.0~"}
+  "coq-mathcomp-ssreflect" {>= "2.0.0"}
   "coq-parseque" {>= "0.2.0"}
   "cmdliner" {>= "1.1.0"}
   "linenoise" {>= "1.4.0"}

--- a/dune-project
+++ b/dune-project
@@ -16,7 +16,7 @@
     (coq (and (>= 8.20) (< 8.21~)))
     (coq-compcert (>= 3.14))
     (coq-ext-lib (>= 0.11.8))
-    (coq-mathcomp-ssreflect (< 2.0.0~))
+    (coq-mathcomp-ssreflect (>= 2.0.0))
     (coq-parseque (>= 0.2.0))
     (cmdliner (>= 1.1.0))
     (linenoise (>= 1.4.0))

--- a/theories/bytes.v
+++ b/theories/bytes.v
@@ -28,13 +28,7 @@ Definition eqbyteP : Equality.axiom byte_eqb :=
 HB.instance Definition _ := hasDecEq.Build byte eqbyteP.
 
 Definition bytes := seq byte.
-
-Definition bytes_eq_dec : forall (a b : bytes), {a = b} + {a <> b}.
-Proof. apply: List.list_eq_dec. apply: byte_eq_dec. Defined.
-Definition bytes_eqb (a b : bytes) := is_left (bytes_eq_dec a b).
-Definition eqbytesP : Equality.axiom bytes_eqb :=
-  eq_dec_Equality_axiom bytes_eq_dec.
-
+  
 Fixpoint bytes_takefill (a : byte) (n : nat) (aas : bytes) : bytes :=
   match n with
   | O => nil

--- a/theories/bytes.v
+++ b/theories/bytes.v
@@ -5,6 +5,7 @@ From mathcomp Require Import ssreflect ssrbool ssrnat eqtype seq.
 Require Import common.
 From compcert Require Import Integers.
 From parseque Require Import Char.
+From HB Require Import structures.
 
 Definition byte := Integers.byte.
 
@@ -24,9 +25,7 @@ Definition byte_eqb a b := is_left (byte_eq_dec a b).
 Definition eqbyteP : Equality.axiom byte_eqb :=
   eq_dec_Equality_axiom byte_eq_dec.
 
-Canonical Structure byte_eqMixin := EqMixin eqbyteP.
-Canonical Structure byte_eqType := Eval hnf in EqType byte byte_eqMixin.
-
+HB.instance Definition _ := hasDecEq.Build byte eqbyteP.
 
 Definition bytes := seq byte.
 

--- a/theories/bytes.v
+++ b/theories/bytes.v
@@ -14,18 +14,12 @@ Instance EqDec_byte : EqDec.EqDec byte := {
   EqDec.eq_dec := Integers.Byte.eq_dec;
 }.
 
-Fixpoint encode (n : nat) : byte :=
-  match n with
-  | 0 => Integers.Byte.zero
-  | S n' => Integers.Byte.add Integers.Byte.one (encode n')
-  end.
-
 Definition byte_eq_dec : forall (a b : byte), _ := EqDec.eq_dec.
 Definition byte_eqb a b := is_left (byte_eq_dec a b).
 Definition eqbyteP : Equality.axiom byte_eqb :=
   eq_dec_Equality_axiom byte_eq_dec.
 
-HB.instance Definition _ := hasDecEq.Build byte eqbyteP.
+HB.instance Definition byte_eqMixin := hasDecEq.Build byte eqbyteP.
 
 Definition bytes := seq byte.
   
@@ -49,15 +43,51 @@ Definition msbyte (bs : bytes) : option byte :=
   last_error bs.
 
 Definition compcert_byte_of_byte (b : Byte.byte) : byte :=
-  (* TODO: this is not great *)
-  encode (Byte.to_nat b).
+  Byte.repr (BinInt.Z.of_N (Byte.to_N b)).
+
+Definition encode (z: BinNums.Z) : byte :=
+  Byte.repr z.
 
 Definition byte_of_compcert_byte (b : byte) : Byte.byte :=
-  (* TODO: is that correct? *)
-  match Byte.of_nat (BinInt.Z.to_nat b.(Byte.intval)) with
+  match Byte.of_N (BinInt.Z.to_N (Byte.unsigned b)) with
   | None => Byte.x00
   | Some b' => b'
   end.
+
+Require Import ZArith.
+
+Theorem compcert_byte_roundtrip: forall (b: byte),
+    compcert_byte_of_byte (byte_of_compcert_byte b) = b.
+Proof.
+  move => b.
+  unfold compcert_byte_of_byte, byte_of_compcert_byte.
+  destruct (Byte.of_N _) as [b0 |] eqn:HofN.
+  - apply Byte.to_of_N in HofN.
+    rewrite HofN.
+    rewrite Znat.Z2N.id.
+    + by rewrite Byte.repr_unsigned.
+    + by apply Byte.unsigned_range.
+  - apply Byte.of_N_None_iff in HofN.
+    exfalso.
+    specialize (Byte.unsigned_range b) as [Hrange1 Hrange2].
+    unfold Byte.modulus, Byte.wordsize, Wordsize_8.wordsize in Hrange2.
+    replace (two_power_nat 8) with (256%Z) in Hrange2; by lias.
+Qed.
+
+Theorem coq_byte_roundtrip: forall (b: Byte.byte),
+    byte_of_compcert_byte (compcert_byte_of_byte b) = b.
+Proof.
+  move => b.
+  unfold compcert_byte_of_byte, byte_of_compcert_byte.
+  Search Byte.unsigned Byte.repr.
+  rewrite Byte.unsigned_repr_eq Z2N.inj_mod; try by lias.
+  rewrite N2Z.id.
+  rewrite N.mod_small; first by rewrite Byte.of_to_N.
+  unfold Byte.modulus, Byte.wordsize, Wordsize_8.wordsize.
+  replace (two_power_nat 8) with (256%Z) by lias.
+  specialize (Byte.to_N_bounded b).
+  by lias.
+Qed.
 
 Declare Scope byte_scope.
 Delimit Scope byte_scope with byte.
@@ -326,4 +356,3 @@ Notation "#FC" := (encode (#F * 16 + #C)) : byte_scope.
 Notation "#FD" := (encode (#F * 16 + #D)) : byte_scope.
 Notation "#FE" := (encode (#F * 16 + #E)) : byte_scope.
 Notation "#FF" := (encode (#F * 16 + #F)) : byte_scope.
-

--- a/theories/contexts.v
+++ b/theories/contexts.v
@@ -3,6 +3,7 @@
     guaranteed to be linear. **)
 
 From mathcomp Require Import ssreflect ssrfun ssrnat ssrbool eqtype seq.
+From HB Require Import structures.
 From Coq Require Import Program NArith ZArith Wf_nat.
 From Wasm Require Export common operations datatypes_properties properties opsem typing_inversion tactic.
 Require Import FunInd Recdef.
@@ -73,11 +74,10 @@ Proof.
 Qed.
 
 Definition label_ctx_eqb (v1 v2: label_ctx) : bool := label_ctx_eq_dec v1 v2.
-Definition eqlabel_ctx: Equality.axiom label_ctx_eqb :=
+Definition eqlabel_ctxP: Equality.axiom label_ctx_eqb :=
   eq_dec_Equality_axiom label_ctx_eq_dec.
 
-Canonical Structure label_ctx_eqMixin := EqMixin eqlabel_ctx.
-Canonical Structure label_ctx_eqType := Eval hnf in EqType label_ctx label_ctx_eqMixin.
+HB.instance Definition label_ctx_eqMixin := hasDecEq.Build label_ctx eqlabel_ctxP.
 
 Definition label_ctx_fill := (fun es ctx => (vs_to_es (LC_val ctx) ++ [::AI_label (LC_arity ctx) (LC_cont ctx) es] ++ (LC_post ctx))).
 
@@ -107,11 +107,10 @@ Proof.
 Qed.
 
 Definition frame_ctx_eqb (v1 v2: frame_ctx) : bool := frame_ctx_eq_dec v1 v2.
-Definition eqframe_ctx: Equality.axiom frame_ctx_eqb :=
+Definition eqframe_ctxP: Equality.axiom frame_ctx_eqb :=
   eq_dec_Equality_axiom frame_ctx_eq_dec.
 
-Canonical Structure frame_ctx_eqMixin := EqMixin eqframe_ctx.
-Canonical Structure frame_ctx_eqType := Eval hnf in EqType frame_ctx frame_ctx_eqMixin.
+HB.instance Definition frame_ctx_eqMixin := hasDecEq.Build frame_ctx eqframe_ctxP.
 
 #[refine, export]
 Instance frame_ctx_eval: eval_ctx frame_ctx :=

--- a/theories/datatypes.v
+++ b/theories/datatypes.v
@@ -179,18 +179,6 @@ Inductive function_type := (* tf *)
 the same as function types. *)
 Definition instr_type := function_type.
 
-(*
-This is technically part of the spec, but the actual definitions never used the bottom case concretely except for the type checking algorithm.
-(** std-doc:
-Instructions are classified by stack types [t1∗]→[t2∗] that describe how instructions manipulate the operand stack.
- *)
-Definition operand_type := option value_type.
-
-Inductive stack_type :=
-| Tfs: list operand_type -> list operand_type -> stack_type
-.
-*)
-
 (** std-doc:
 Limits classify the size range of resizeable storage associated with memory types and table types.
 If no maximum is given, the respective storage can grow to any size.
@@ -317,27 +305,6 @@ Definition serialise_f32 (f : f32) : bytes :=
 
 Definition serialise_f64 (f : f64) : bytes :=
   common.Memdata.encode_int 8%nat (Integers.Int64.unsigned (numerics.Wasm_float.FloatSize64.to_bits f)).
-
-(*
-(* TODO: factor this out, following the `memory` branch *)
-Module Byte_Index <: array.Index_Sig.
-Definition Index := N.
-Definition Value := byte.
-Definition index_eqb := N.eqb.
-End Byte_Index.
-
-Module Byte_array := array.Make Byte_Index.
-
-Record data_vec : Set := {
-  dv_length : N;
-  dv_array : Byte_array.array;
-}.
-
-Record memory : Set := {
-  mem_data : memory_list;
-  mem_max_opt: option N; (* TODO: should be u32 *)
-}.
-*)
 
   
 Section Instructions.

--- a/theories/datatypes_properties.v
+++ b/theories/datatypes_properties.v
@@ -3,6 +3,7 @@
 
 From Wasm Require Export datatypes.
 From mathcomp Require Import ssreflect ssrfun ssrnat ssrbool eqtype seq.
+From HB Require Import structures.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -16,17 +17,13 @@ Definition ascii_eqb v1 v2 : bool := ascii_eq_dec v1 v2.
 Definition eqasciiP : Equality.axiom ascii_eqb :=
   eq_dec_Equality_axiom ascii_eq_dec.
 
-Canonical Structure ascii_eqMixin := EqMixin eqasciiP.
-Canonical Structure ascii_eqType :=
-  Eval hnf in EqType Ascii.ascii ascii_eqMixin.
+HB.instance Definition ascii_eqMixin := hasDecEq.Build Ascii.ascii eqasciiP.
 
 Definition byte_eqb v1 v2 : bool := Byte.byte_eq_dec v1 v2.
 Definition eqbyteP : Equality.axiom byte_eqb :=
   eq_dec_Equality_axiom Byte.byte_eq_dec.
 
-Canonical Structure byte_eqMixin := EqMixin eqbyteP.
-Canonical Structure byte_eqType :=
-  Eval hnf in EqType Byte.byte byte_eqMixin.
+HB.instance Definition byte_eqMixin := hasDecEq.Build Byte.byte eqbyteP.
 
 Definition name_eq_dec : forall tf1 tf2 : name,
   {tf1 = tf2} + {tf1 <> tf2}.
@@ -35,57 +32,49 @@ Definition name_eqb v1 v2 := is_left (name_eq_dec v1 v2).
 Definition eqnameP  : Equality.axiom name_eqb :=
   eq_dec_Equality_axiom name_eq_dec.
 
-Canonical Structure name_eqMixin := EqMixin eqnameP.
-Canonical Structure name_eqType :=
-  Eval hnf in EqType name name_eqMixin.
+HB.instance Definition name_eqMixin := hasDecEq.Build name eqnameP.
 
 Scheme Equality for number_type.
 Definition number_type_eqb v1 v2 : bool := number_type_eq_dec v1 v2.
 Definition eqnumber_typeP : Equality.axiom number_type_eqb :=
   eq_dec_Equality_axiom number_type_eq_dec.
 
-Canonical Structure number_type_eqMixin := EqMixin eqnumber_typeP.
-Canonical Structure number_type_eqType := Eval hnf in EqType number_type number_type_eqMixin.
+HB.instance Definition number_type_eqMixin := hasDecEq.Build number_type eqnumber_typeP.
 
 Scheme Equality for reference_type.
 Definition reference_type_eqb v1 v2 : bool := reference_type_eq_dec v1 v2.
 Definition eqreference_typeP : Equality.axiom reference_type_eqb :=
   eq_dec_Equality_axiom reference_type_eq_dec.
 
-Canonical Structure reference_type_eqMixin := EqMixin eqreference_typeP.
-Canonical Structure reference_type_eqType := Eval hnf in EqType reference_type reference_type_eqMixin.
+HB.instance Definition reference_type_eqMixin := hasDecEq.Build reference_type eqreference_typeP.
 
 Scheme Equality for value_type.
 Definition value_type_eqb v1 v2 : bool := value_type_eq_dec v1 v2.
 Definition eqvalue_typeP : Equality.axiom value_type_eqb :=
   eq_dec_Equality_axiom value_type_eq_dec.
 
-Canonical Structure value_type_eqMixin := EqMixin eqvalue_typeP.
-Canonical Structure value_type_eqType := Eval hnf in EqType value_type value_type_eqMixin.
+HB.instance Definition value_type_eqMixin := hasDecEq.Build value_type eqvalue_typeP.
 
 Scheme Equality for packed_type.
 Definition packed_type_eqb v1 v2 : bool := packed_type_eq_dec v1 v2.
 Definition eqpacked_typeP : Equality.axiom packed_type_eqb :=
   eq_dec_Equality_axiom packed_type_eq_dec.
 
-Canonical Structure packed_type_eqMixin := EqMixin eqpacked_typeP.
-Canonical Structure packed_type_eqType := Eval hnf in EqType packed_type packed_type_eqMixin.
+HB.instance Definition packed_type_eqMixin := hasDecEq.Build packed_type eqpacked_typeP.
 
 Scheme Equality for mutability.
 Definition mutability_eqb v1 v2 : bool := mutability_eq_dec v1 v2.
 Definition eqmutabilityP : Equality.axiom mutability_eqb :=
   eq_dec_Equality_axiom mutability_eq_dec.
 
-Canonical Structure mutability_eqMixin := EqMixin eqmutabilityP.
-Canonical Structure mutability_eqType := Eval hnf in EqType mutability mutability_eqMixin.
+HB.instance Definition mutability_eqMixin := hasDecEq.Build mutability eqmutabilityP.
 
 Scheme Equality for global_type.
 Definition global_type_eqb v1 v2 : bool := global_type_eq_dec v1 v2.
 Definition eqglobal_typeP : Equality.axiom global_type_eqb :=
   eq_dec_Equality_axiom global_type_eq_dec.
 
-Canonical Structure global_type_eqMixin := EqMixin eqglobal_typeP.
-Canonical Structure global_type_eqType := Eval hnf in EqType global_type global_type_eqMixin.
+HB.instance Definition global_type_eqMixin := hasDecEq.Build global_type eqglobal_typeP.
 
 Definition function_type_eq_dec : forall tf1 tf2 : function_type,
   {tf1 = tf2} + {tf1 <> tf2}.
@@ -95,9 +84,7 @@ Definition function_type_eqb v1 v2 : bool := function_type_eq_dec v1 v2.
 Definition eqfunction_typeP : Equality.axiom function_type_eqb :=
   eq_dec_Equality_axiom function_type_eq_dec.
 
-Canonical Structure function_type_eqMixin := EqMixin eqfunction_typeP.
-Canonical Structure function_type_eqType :=
-  Eval hnf in EqType function_type function_type_eqMixin.
+HB.instance Definition function_type_eqMixin := hasDecEq.Build function_type eqfunction_typeP.
 
 Definition t_context_eq_dec : forall x y : t_context, {x = y} + {x <> y}.
 Proof. decidable_equality. Defined.
@@ -106,80 +93,70 @@ Definition t_context_eqb v1 v2 : bool := t_context_eq_dec v1 v2.
 Definition eqt_contextP : Equality.axiom t_context_eqb :=
   eq_dec_Equality_axiom t_context_eq_dec.
 
-Canonical Structure t_context_eqMixin := EqMixin eqt_contextP.
-Canonical Structure t_context_eqType := Eval hnf in EqType t_context t_context_eqMixin.
+HB.instance Definition t_context_eqMixin := hasDecEq.Build t_context eqt_contextP.
 
 Scheme Equality for sx.
 Definition sx_eqb v1 v2 : bool := sx_eq_dec v1 v2.
 Definition eqsxP : Equality.axiom sx_eqb :=
   eq_dec_Equality_axiom sx_eq_dec.
 
-Canonical Structure sx_eqMixin := EqMixin eqsxP.
-Canonical Structure sx_eqType := Eval hnf in EqType sx sx_eqMixin.
+HB.instance Definition sx_eqMixin := hasDecEq.Build sx eqsxP.
 
 Scheme Equality for unop_i.
 Definition unop_i_eqb v1 v2 : bool := unop_i_eq_dec v1 v2.
 Definition equnop_iP : Equality.axiom unop_i_eqb :=
   eq_dec_Equality_axiom unop_i_eq_dec.
 
-Canonical Structure unop_i_eqMixin := EqMixin equnop_iP.
-Canonical Structure unop_i_eqType := Eval hnf in EqType unop_i unop_i_eqMixin.
+HB.instance Definition unop_i_eqMixin := hasDecEq.Build unop_i equnop_iP.
 
 Scheme Equality for unop_f.
 Definition unop_f_eqb v1 v2 : bool := unop_f_eq_dec v1 v2.
 Definition equnop_fP : Equality.axiom unop_f_eqb :=
   eq_dec_Equality_axiom unop_f_eq_dec.
 
-Canonical Structure unop_f_eqMixin := EqMixin equnop_fP.
-Canonical Structure unop_f_eqType := Eval hnf in EqType unop_f unop_f_eqMixin.
+HB.instance Definition unop_f_eqMixin := hasDecEq.Build unop_f equnop_fP.
 
 Scheme Equality for binop_i.
 Definition binop_i_eqb v1 v2 : bool := binop_i_eq_dec v1 v2.
 Definition eqbinop_iP : Equality.axiom binop_i_eqb :=
   eq_dec_Equality_axiom binop_i_eq_dec.
 
-Canonical Structure binop_i_eqMixin := EqMixin eqbinop_iP.
-Canonical Structure binop_i_eqType := Eval hnf in EqType binop_i binop_i_eqMixin.
+HB.instance Definition binop_i_eqMixin := hasDecEq.Build binop_i eqbinop_iP.
 
 Scheme Equality for binop_f.
 Definition binop_f_eqb v1 v2 : bool := binop_f_eq_dec v1 v2.
 Definition eqbinop_fP : Equality.axiom binop_f_eqb :=
   eq_dec_Equality_axiom binop_f_eq_dec.
 
-Canonical Structure binop_f_eqMixin := EqMixin eqbinop_fP.
-Canonical Structure binop_f_eqType := Eval hnf in EqType binop_f binop_f_eqMixin.
+HB.instance Definition binop_f_eqMixin := hasDecEq.Build binop_f eqbinop_fP.
 
 Scheme Equality for testop.
 Definition testop_eqb v1 v2 : bool := testop_eq_dec v1 v2.
 Definition eqtestopP : Equality.axiom testop_eqb :=
   eq_dec_Equality_axiom testop_eq_dec.
 
-Canonical Structure testop_eqMixin := EqMixin eqtestopP.
-Canonical Structure testop_eqType := Eval hnf in EqType testop testop_eqMixin.
+HB.instance Definition testop_eqMixin := hasDecEq.Build testop eqtestopP.
 
 Scheme Equality for relop_i.
 Definition relop_i_eqb v1 v2 : bool := relop_i_eq_dec v1 v2.
 Definition eqrelop_iP : Equality.axiom relop_i_eqb :=
   eq_dec_Equality_axiom relop_i_eq_dec.
 
-Canonical Structure relop_i_eqMixin := EqMixin eqrelop_iP.
-Canonical Structure relop_i_eqType := Eval hnf in EqType relop_i relop_i_eqMixin.
+HB.instance Definition relop_i_eqMixin := hasDecEq.Build relop_i eqrelop_iP.
 
 Scheme Equality for relop_f.
 Definition relop_f_eqb v1 v2 : bool := relop_f_eq_dec v1 v2.
 Definition eqrelop_fP : Equality.axiom relop_f_eqb :=
   eq_dec_Equality_axiom relop_f_eq_dec.
 
-Canonical Structure relop_f_eqMixin := EqMixin eqrelop_fP.
-Canonical Structure relop_f_eqType := Eval hnf in EqType relop_f relop_f_eqMixin.
+HB.instance Definition relop_f_eqMixin := hasDecEq.Build relop_f eqrelop_fP.
 
 Scheme Equality for cvtop.
 Definition cvtop_eqb v1 v2 : bool := cvtop_eq_dec v1 v2.
 Definition eqcvtopP : Equality.axiom cvtop_eqb :=
   eq_dec_Equality_axiom cvtop_eq_dec.
 
-Canonical Structure cvtop_eqMixin := EqMixin eqcvtopP.
-Canonical Structure cvtop_eqType := Eval hnf in EqType cvtop cvtop_eqMixin.
+HB.instance Definition cvtop_eqMixin := hasDecEq.Build cvtop eqcvtopP.
 
 Definition value_eq_dec : forall v1 v2 : value, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -188,8 +165,7 @@ Definition value_eqb v1 v2 : bool := value_eq_dec v1 v2.
 Definition eqvalueP : Equality.axiom value_eqb :=
   eq_dec_Equality_axiom value_eq_dec.
 
-Canonical Structure value_eqMixin := EqMixin eqvalueP.
-Canonical Structure value_eqType := Eval hnf in EqType value value_eqMixin.
+HB.instance Definition value_eqMixin := hasDecEq.Build value eqvalueP.
 
 Definition value_num_eq_dec : forall v1 v2 : value_num, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -198,8 +174,7 @@ Definition value_num_eqb v1 v2 : bool := value_num_eq_dec v1 v2.
 Definition eqvalue_numP : Equality.axiom value_num_eqb :=
   eq_dec_Equality_axiom value_num_eq_dec.
 
-Canonical Structure value_num_eqMixin := EqMixin eqvalue_numP.
-Canonical Structure value_num_eqType := Eval hnf in EqType value_num value_num_eqMixin.
+HB.instance Definition value_num_eqMixin := hasDecEq.Build value_num eqvalue_numP.
 
 Definition value_ref_eq_dec : forall v1 v2 : value_ref, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -208,17 +183,7 @@ Definition value_ref_eqb v1 v2 : bool := value_ref_eq_dec v1 v2.
 Definition eqvalue_refP : Equality.axiom value_ref_eqb :=
   eq_dec_Equality_axiom value_ref_eq_dec.
 
-Canonical Structure value_ref_eqMixin := EqMixin eqvalue_refP.
-Canonical Structure value_ref_eqType := Eval hnf in EqType value_ref value_ref_eqMixin.
-
-Definition u32_eq_dec : forall v1 v2: u32, {v1 = v2} + {v1 <> v2}.
-Proof. decidable_equality. Defined.
-
-Definition u32_eqb v1 v2 : bool := u32_eq_dec v1 v2.
-Definition equ32P : Equality.axiom u32_eqb := eq_dec_Equality_axiom u32_eq_dec.
-
-Canonical Structure u32_eqMixin := EqMixin equ32P.
-Canonical Structure u32_eqType := Eval hnf in EqType u32 u32_eqMixin.
+HB.instance Definition value_ref_eqMixin := hasDecEq.Build value_ref eqvalue_refP.
 
 Definition extern_type_eq_dec : forall v1 v2 : extern_type, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -227,8 +192,7 @@ Definition extern_type_eqb v1 v2 : bool := extern_type_eq_dec v1 v2.
 Definition eqextern_typeP : Equality.axiom extern_type_eqb :=
   eq_dec_Equality_axiom extern_type_eq_dec.
 
-Canonical Structure extern_type_eqMixin := EqMixin eqextern_typeP.
-Canonical Structure extern_type_eqType := Eval hnf in EqType extern_type extern_type_eqMixin.
+HB.instance Definition extern_type_eqMixin := hasDecEq.Build extern_type eqextern_typeP.
 
 (** Induction scheme for [basic_instruction]. **)
 Definition basic_instruction_rect' :=
@@ -246,9 +210,7 @@ Definition basic_instruction_eqb cl1 cl2 : bool :=
 Definition eqbasic_instructionP : Equality.axiom basic_instruction_eqb :=
   eq_dec_Equality_axiom basic_instruction_eq_dec.
 
-Canonical Structure basic_instruction_eqMixin := EqMixin eqbasic_instructionP.
-Canonical Structure basic_instruction_eqType :=
-  Eval hnf in EqType basic_instruction basic_instruction_eqMixin.
+HB.instance Definition basic_instruction_eqMixin := hasDecEq.Build basic_instruction eqbasic_instructionP.
 
 Definition moduleinst_eq_dec : forall (i1 i2 : moduleinst), {i1 = i2} + {i1 <> i2}.
 Proof. decidable_equality. Defined.
@@ -258,8 +220,7 @@ Definition moduleinst_eqb i1 i2 : bool := moduleinst_eq_dec i1 i2.
 Definition eqmoduleinstP : Equality.axiom moduleinst_eqb :=
   eq_dec_Equality_axiom moduleinst_eq_dec.
 
-Canonical Structure moduleinst_eqMixin := EqMixin eqmoduleinstP.
-Canonical Structure moduleinst_eqType := Eval hnf in EqType moduleinst moduleinst_eqMixin.
+HB.instance Definition moduleinst_eqMixin := hasDecEq.Build moduleinst eqmoduleinstP.
 
 Definition administrative_instruction_rect :=
   @administrative_instruction_rect
@@ -279,9 +240,7 @@ Definition funcinst_eqb cl1 cl2 : bool := funcinst_eq_dec cl1 cl2.
 Definition eqfuncinstP : Equality.axiom funcinst_eqb :=
   eq_dec_Equality_axiom funcinst_eq_dec.
 
-Canonical Structure funcinst_eqMixin := EqMixin eqfuncinstP.
-Canonical Structure funcinst_eqType :=
-  Eval hnf in EqType funcinst funcinst_eqMixin.
+HB.instance Definition funcinst_eqMixin := hasDecEq.Build funcinst eqfuncinstP.
 
 Definition tableinst_eq_dec : forall v1 v2 : tableinst, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -290,8 +249,7 @@ Definition tableinst_eqb v1 v2 : bool := tableinst_eq_dec v1 v2.
 Definition eqtableinstP : Equality.axiom tableinst_eqb :=
   eq_dec_Equality_axiom tableinst_eq_dec.
 
-Canonical Structure tableinst_eqMixin := EqMixin eqtableinstP.
-Canonical Structure tableinst_eqType := Eval hnf in EqType tableinst tableinst_eqMixin.
+HB.instance Definition tableinst_eqMixin := hasDecEq.Build tableinst eqtableinstP.
 
 Definition globalinst_eq_dec : forall v1 v2 : globalinst, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -300,8 +258,7 @@ Definition globalinst_eqb v1 v2 : bool := globalinst_eq_dec v1 v2.
 Definition eqglobalinstP : Equality.axiom globalinst_eqb :=
   eq_dec_Equality_axiom globalinst_eq_dec.
 
-Canonical Structure globalinst_eqMixin := EqMixin eqglobalinstP.
-Canonical Structure globalinst_eqType := Eval hnf in EqType globalinst globalinst_eqMixin.
+HB.instance Definition globalinst_eqMixin := hasDecEq.Build globalinst eqglobalinstP.
 
 Definition eleminst_eq_dec : forall v1 v2 : eleminst, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -310,8 +267,7 @@ Definition eleminst_eqb v1 v2 : bool := eleminst_eq_dec v1 v2.
 Definition eqeleminstP : Equality.axiom eleminst_eqb :=
   eq_dec_Equality_axiom eleminst_eq_dec.
 
-Canonical Structure eleminst_eqMixin := EqMixin eqeleminstP.
-Canonical Structure eleminst_eqType := Eval hnf in EqType eleminst eleminst_eqMixin.
+HB.instance Definition eleminst_eqMixin := hasDecEq.Build eleminst eqeleminstP.
 
 Definition datainst_eq_dec : forall v1 v2 : datainst, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -320,8 +276,7 @@ Definition datainst_eqb v1 v2 : bool := datainst_eq_dec v1 v2.
 Definition eqdatainstP : Equality.axiom datainst_eqb :=
   eq_dec_Equality_axiom datainst_eq_dec.
 
-Canonical Structure datainst_eqMixin := EqMixin eqdatainstP.
-Canonical Structure datainst_eqType := Eval hnf in EqType datainst datainst_eqMixin.
+HB.instance Definition datainst_eqMixin := hasDecEq.Build datainst eqdatainstP.
 
 Definition exportinst_eq_dec : forall v1 v2 : exportinst, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -330,8 +285,7 @@ Definition exportinst_eqb v1 v2 : bool := exportinst_eq_dec v1 v2.
 Definition eqexportinstP : Equality.axiom exportinst_eqb :=
   eq_dec_Equality_axiom exportinst_eq_dec.
 
-Canonical Structure exportinst_eqMixin := EqMixin eqexportinstP.
-Canonical Structure exportinst_eqType := Eval hnf in EqType exportinst exportinst_eqMixin.
+HB.instance Definition exportinst_eqMixin := hasDecEq.Build exportinst eqexportinstP.
 
 Definition store_record_eq_dec : forall v1 v2 : store_record, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -340,8 +294,7 @@ Definition store_record_eqb v1 v2 : bool := store_record_eq_dec v1 v2.
 Definition eqstore_recordP : Equality.axiom store_record_eqb :=
   eq_dec_Equality_axiom store_record_eq_dec.
 
-Canonical Structure store_record_eqMixin := EqMixin eqstore_recordP.
-Canonical Structure store_record_eqType := Eval hnf in EqType store_record store_record_eqMixin.
+HB.instance Definition store_record_eqMixin := hasDecEq.Build store_record eqstore_recordP.
 
 Definition frame_eq_dec : forall v1 v2 : frame, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -350,8 +303,7 @@ Definition frame_eqb v1 v2 : bool := frame_eq_dec v1 v2.
 Definition eqframeP : Equality.axiom frame_eqb :=
   eq_dec_Equality_axiom frame_eq_dec.
 
-Canonical Structure frame_eqMixin := EqMixin eqframeP.
-Canonical Structure frame_eqType := Eval hnf in EqType frame frame_eqMixin.
+HB.instance Definition frame_eqMixin := hasDecEq.Build frame eqframeP.
 
 Definition module_export_desc_eq_dec : forall v1 v2 : module_export_desc, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -360,9 +312,7 @@ Definition module_export_desc_eqb v1 v2 : bool := module_export_desc_eq_dec v1 v
 Definition eqmodule_export_descP : Equality.axiom module_export_desc_eqb :=
   eq_dec_Equality_axiom module_export_desc_eq_dec.
 
-Canonical Structure module_export_desc_eqMixin := EqMixin eqmodule_export_descP.
-Canonical Structure module_export_desc_eqType :=
-  Eval hnf in EqType module_export_desc module_export_desc_eqMixin.
+HB.instance Definition module_export_desc_eqMixin := hasDecEq.Build module_export_desc eqmodule_export_descP.
 
 Definition module_export_eq_dec : forall v1 v2 : module_export, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -371,8 +321,7 @@ Definition module_export_eqb v1 v2 : bool := module_export_eq_dec v1 v2.
 Definition eqmodule_exportP : Equality.axiom module_export_eqb :=
   eq_dec_Equality_axiom module_export_eq_dec.
 
-Canonical Structure module_export_eqMixin := EqMixin eqmodule_exportP.
-Canonical Structure module_export_eqType := Eval hnf in EqType module_export module_export_eqMixin.
+HB.instance Definition module_export_eqMixin := hasDecEq.Build module_export eqmodule_exportP.
 
 (** Induction scheme for [administrative_instruction]. **)
 Definition administrative_instruction_rect' :=
@@ -402,9 +351,7 @@ Definition administrative_instruction_eqb cl1 cl2 : bool :=
 Definition eqadministrative_instructionP : Equality.axiom administrative_instruction_eqb :=
   eq_dec_Equality_axiom administrative_instruction_eq_dec.
 
-Canonical Structure administrative_instruction_eqMixin := EqMixin eqadministrative_instructionP.
-Canonical Structure administrative_instruction_eqType :=
-  Eval hnf in EqType administrative_instruction administrative_instruction_eqMixin.
+HB.instance Definition administrative_instruction_eqMixin := hasDecEq.Build administrative_instruction eqadministrative_instructionP.
 
 End Host.
 
@@ -509,8 +456,7 @@ Definition lholed_eqb {k} (v1 v2: lholed k) : bool := lholed_eq_dec v1 v2.
 Definition eqlholedP {k} :=
   eq_dec_Equality_axiom (@lholed_eq_dec k).
 
-Canonical Structure lholed_eqMixin {k} := EqMixin (@eqlholedP k).
-Canonical Structure lholed_eqType {k} := Eval hnf in EqType (@lholed k) (@lholed_eqMixin k).
+HB.instance Definition lholed_eqMixin {k} := hasDecEq.Build (lholed k) (@eqlholedP k).
 
 End lholed_eqdec.
 
@@ -521,9 +467,7 @@ Definition limits_eqb v1 v2 : bool := limits_eq_dec v1 v2.
 Definition eqlimitsP : Equality.axiom limits_eqb :=
   eq_dec_Equality_axiom limits_eq_dec.
 
-Canonical Structure limits_eqMixin := EqMixin eqlimitsP.
-Canonical Structure limits_eqType := Eval hnf in EqType limits limits_eqMixin.
-
+HB.instance Definition limits_eqMixin := hasDecEq.Build limits eqlimitsP.
 
 Definition table_type_eq_dec : forall v1 v2 : table_type, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -531,8 +475,7 @@ Definition table_type_eqb v1 v2 : bool := table_type_eq_dec v1 v2.
 Definition eqtable_typeP : Equality.axiom table_type_eqb :=
   eq_dec_Equality_axiom table_type_eq_dec.
 
-Canonical Structure table_type_eqMixin := EqMixin eqtable_typeP.
-Canonical Structure table_type_eqType := Eval hnf in EqType table_type table_type_eqMixin.
+HB.instance Definition table_type_eqMixin := hasDecEq.Build table_type eqtable_typeP.
 
 Definition memory_type_eq_dec : forall v1 v2 : memory_type, {v1 = v2} + {v1 <> v2}.
 Proof. decidable_equality. Defined.
@@ -540,6 +483,5 @@ Definition memory_type_eqb v1 v2 : bool := memory_type_eq_dec v1 v2.
 Definition eqmemory_typeP : Equality.axiom memory_type_eqb :=
   eq_dec_Equality_axiom memory_type_eq_dec.
 
-Canonical Structure memory_type_eqMixin := EqMixin eqmemory_typeP.
-Canonical Structure memory_type_eqType := Eval hnf in EqType memory_type memory_type_eqMixin.
+HB.instance Definition memory_type_eqMixin := hasDecEq.Build memory_type eqmemory_typeP.
 

--- a/theories/host.v
+++ b/theories/host.v
@@ -2,6 +2,7 @@
 (* (C) M. Bodin - see LICENSE.txt *)
 
 From mathcomp Require Import ssreflect ssrfun ssrnat ssrbool eqtype seq.
+From HB Require Import structures.
 From Wasm Require Import common datatypes operations typing.
 From ExtLib Require Import Structures.Monad.
 
@@ -127,9 +128,7 @@ Definition host_function_eqb f1 f2 : bool := host_function_eq_dec f1 f2.
 Definition host_functionP : Equality.axiom host_function_eqb :=
   eq_dec_Equality_axiom host_function_eq_dec.
 
-Global Canonical Structure host_function_eqMixin := EqMixin host_functionP.
-Global Canonical Structure host_function_eqType :=
-  Eval hnf in EqType _ host_function_eqMixin.
+HB.instance Definition host_function_eqMixin := hasDecEq.Build host_function host_functionP.
 
 Definition host_monad : Monad host_event := {|
     ret := host_ret ;
@@ -177,7 +176,7 @@ Definition host_apply (_ : store_record) (_ : function_type) :=
 Instance host_instance : host.
 Proof.
   by refine {|
-      host_state := unit_eqType ;
+      host_state := unit;
       host_application _ _ _ _ _ _ _ := False
     |}.
 Defined.

--- a/theories/interpreter_ctx.v
+++ b/theories/interpreter_ctx.v
@@ -586,13 +586,13 @@ the condition that all values should live in the operand stack. *)
       (* i32 *)
       + destruct v as [c| | |].
         2,3,4: by resolve_invalid_typing; resolve_invalid_value. 
-        apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 (wasm_bool (@app_testop_i i32t testop c))) :: vs0, es0), None)>> => //.
+        apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 (wasm_bool (app_testop_i i32m testop c))) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple, rs_testop_i32.
       (* i64 *)
       + destruct v as [|c | |].
         1,3,4: by resolve_invalid_typing; resolve_invalid_value.
-        apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 (wasm_bool (@app_testop_i i64t testop c))) :: vs0, es0), None)>> => //.
+        apply <<hs, (s, (fc, lcs) :: ccs', (VAL_num (VAL_int32 (wasm_bool (app_testop_i i64m testop c))) :: vs0, es0), None)>> => //.
         resolve_reduce_ctx vs0 es0.
         by apply r_simple, rs_testop_i64.
 
@@ -1788,7 +1788,7 @@ Export DummyHost.
 Instance host_instance : host.
 Proof.
   by refine {|
-      host_state := unit_eqType ;
+      host_state := unit;
       host_application _ _ _ _ _ _ _ := False
     |}.
 Defined.

--- a/theories/memory.v
+++ b/theories/memory.v
@@ -58,9 +58,11 @@ Definition mem_ax_length_constant_update
   (mem_update : mem_update_t Mem_t) :=
   forall i b mem mem', Some mem' = mem_update i b mem -> mem_length mem' = mem_length mem.
 
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
+
 
 Section ClassDef.
 
@@ -77,6 +79,7 @@ Record mixin_of (Mem_t : Type) : Type := Mixin {
   _ : mem_ax_length_constant_update Mem_t mem_make mem_length mem_grow mem_lookup mem_update;
 }.
 
+(*
 Set Primitive Projections.
 Record class_of (T : Type) : Type := Class {base : Equality.mixin_of T; mixin : mixin_of T}.
 Unset Primitive Projections.
@@ -95,18 +98,24 @@ Definition pack m :=
   fun b bT & phant_id (Equality.class bT) b => Pack (@Class T b m).
 
 Definition eqType := @Equality.Pack cT xclass.
+ *)
 
 End ClassDef.
 
+(*
 Module Import Exports.
+
 Coercion base : class_of >-> Equality.class_of.
 Coercion sort : type >-> Sortclass.
 Coercion eqType : type >-> Equality.type.
 Canonical eqType.
+
 Notation memoryType := type.
 Notation memoryMixin := mixin_of.
 Notation MemoryType T m := (@pack T m _ _ id).
 
 End Exports.
+*)
 
 End Memory.
+

--- a/theories/memory.v
+++ b/theories/memory.v
@@ -79,43 +79,6 @@ Record mixin_of (Mem_t : Type) : Type := Mixin {
   _ : mem_ax_length_constant_update Mem_t mem_make mem_length mem_grow mem_lookup mem_update;
 }.
 
-(*
-Set Primitive Projections.
-Record class_of (T : Type) : Type := Class {base : Equality.mixin_of T; mixin : mixin_of T}.
-Unset Primitive Projections.
-Local Coercion base : class_of >->  Equality.class_of.
-
-Structure type : Type := Pack {sort; _ : class_of sort; }.
-Local Coercion sort : type >-> Sortclass.
-
-Variables (T : Type) (cT : type).
-Definition class := let: Pack _ c as cT' := cT return class_of cT' in c.
-Definition clone c of phant_id class c := @Pack T c.
-Let xT := let: Pack T _ := cT in T.
-Notation xclass := (class : class_of xT).
-
-Definition pack m :=
-  fun b bT & phant_id (Equality.class bT) b => Pack (@Class T b m).
-
-Definition eqType := @Equality.Pack cT xclass.
- *)
-
 End ClassDef.
 
-(*
-Module Import Exports.
-
-Coercion base : class_of >-> Equality.class_of.
-Coercion sort : type >-> Sortclass.
-Coercion eqType : type >-> Equality.type.
-Canonical eqType.
-
-Notation memoryType := type.
-Notation memoryMixin := mixin_of.
-Notation MemoryType T m := (@pack T m _ _ id).
-
-End Exports.
-*)
-
 End Memory.
-

--- a/theories/memory_list.v
+++ b/theories/memory_list.v
@@ -172,6 +172,7 @@ Qed.
 
 
 Require Import bytes common.
+From HB Require Import structures.
 
 Definition memory_list_eq_dec : forall (i1 i2 : memory_list), {i1 = i2} + {i1 <> i2}.
 Proof. decidable_equality. Defined.
@@ -181,9 +182,12 @@ Definition memory_list_eqb i1 i2 : bool := memory_list_eq_dec i1 i2.
 Definition eqmemory_listP : Equality.axiom memory_list_eqb :=
   eq_dec_Equality_axiom memory_list_eq_dec.
 
+HB.instance Definition memory_list_eqMixin := hasDecEq.Build memory_list eqmemory_listP.
+
+(*
 Canonical Structure memory_list_eqMixin := EqMixin eqmemory_listP.
 Canonical Structure memory_list_eqType := Eval hnf in EqType memory_list memory_list_eqMixin.
-
+*)
 Definition list_memoryMixin :=
   Memory.Mixin
     memory_list_ax_lookup_out_of_bounds
@@ -191,5 +195,7 @@ Definition list_memoryMixin :=
     memory_list_ax_lookup_update
     memory_list_ax_lookup_skip
     memory_list_ax_length_constant_update.
+(*
 Definition list_memoryClass := Memory.Class memory_list_eqMixin list_memoryMixin.
 Canonical list_memoryType := @Memory.Pack memory_list list_memoryClass.
+*)

--- a/theories/memory_list.v
+++ b/theories/memory_list.v
@@ -36,49 +36,49 @@ Definition mem_update : Memory.mem_update_t memory_list :=
 Lemma memory_list_ax_lookup_out_of_bounds :
   Memory.mem_ax_lookup_out_of_bounds memory_list mem_make mem_length mem_grow mem_lookup mem_update.
 Proof.
-move => mem i.
-rewrite /mem_length /mem_lookup.
-move => H.
-apply (List.nth_error_None mem.(ml_data) (N.to_nat i)).
-apply N.ge_le in H.
-move: H.
-set x := (length (ml_data mem)).
-move => H.
-lia.
+  move => mem i.
+  rewrite /mem_length /mem_lookup.
+  move => H.
+  apply (List.nth_error_None mem.(ml_data) (N.to_nat i)).
+  apply N.ge_le in H.
+  move: H.
+  set x := (length (ml_data mem)).
+  move => H.
+  lia.
 Qed.
   
 Lemma nth_repeat :
 forall A b i len, i < len ->
 @List.nth_error A (List.repeat b len) i = Some b.
 Proof.
-move => A b.
-elim => [|i].
-{ case => [|len]; first by lia.
-  by move => _. }
-{ move => IH len.
-  case: len => [|len'].
-  { move => Hctr.
-    exfalso.
-    lia. }
-  { move => Hlen /=.
-    apply: IH.
-    lia. } }
+  move => A b.
+  elim => [|i].
+  { case => [|len]; first by lia.
+    by move => _. }
+  { move => IH len.
+    case: len => [|len'].
+    { move => Hctr.
+      exfalso.
+      lia. }
+    { move => Hlen /=.
+      apply: IH.
+      lia. } }
 Qed.
   
 Lemma lookup_split : forall A (l : list A) i b,
   i < List.length l ->
   List.nth_error (take i l ++ b :: drop (i+1) l) i = Some b.
 Proof.
-move => A.
-elim => [|x l].
-{ move => i b /= Hlen.
-  exfalso.
-  lia. }
-{ move => IH.
-  case => [|i]; first by reflexivity.
-  move => b /= Hlen.
-  have Hlen': i < length l by lia.
-  by apply: IH. }
+  move => A.
+  elim => [|x l].
+  { move => i b /= Hlen.
+    exfalso.
+    lia. }
+  { move => IH.
+    case => [|i]; first by reflexivity.
+    move => b /= Hlen.
+    have Hlen': i < length l by lia.
+    by apply: IH. }
 Qed.
   
 Lemma bar : forall A n n' (l : list A) v,
@@ -119,57 +119,56 @@ Qed.
 
 Lemma memory_list_ax_lookup_make : Memory.mem_ax_lookup_make memory_list mem_make mem_length mem_grow mem_lookup mem_update.
 Proof.
-move => i len b mem.
-apply: nth_repeat.
-lia.
+  move => i len b mem.
+  apply: nth_repeat.
+  lia.
 Qed.
 
 Lemma memory_list_ax_lookup_update :
   Memory.mem_ax_lookup_update memory_list mem_make mem_length mem_grow mem_lookup mem_update.
 Proof.
-move => mem mem' i b H H0.
-rewrite /mem_update in H0.
-apply N.ltb_lt in H.
-rewrite /mem_length in H.
-rewrite H in H0.
-case: mem' H0 => init_ data_ [Hinit Hdata].
-rewrite Hinit Hdata /= {init_ data_ Hinit Hdata}.
-set nn := N.to_nat i.
-have Hx: nn < length (ml_data mem).
-apply N.ltb_lt in H.
-lia.
-by apply: lookup_split.
+  move => mem mem' i b H H0.
+  rewrite /mem_update in H0.
+  apply N.ltb_lt in H.
+  rewrite /mem_length in H.
+  rewrite H in H0.
+  case: mem' H0 => init_ data_ [Hinit Hdata].
+  rewrite Hinit Hdata /= {init_ data_ Hinit Hdata}.
+  set nn := N.to_nat i.
+  have Hx: nn < length (ml_data mem).
+  apply N.ltb_lt in H.
+  lia.
+  by apply: lookup_split.
 Qed.
 
 Lemma memory_list_ax_lookup_skip :
   Memory.mem_ax_lookup_skip memory_list mem_make mem_length mem_grow mem_lookup mem_update.
 Proof.
-move => mem mem' i i' b Hii' H0.
-case: mem' H0 => init_ data_.
-rewrite /mem_update /mem_lookup.
-case_eq (N.ltb i' (N.of_nat (length (ml_data mem)))); last by discriminate.
-move => Hlen [Hinit Hdata] /=.
-rewrite Hdata => {Hdata}.
-apply: bar.
-lia.
-apply N.ltb_lt in Hlen.
-lia.
+  move => mem mem' i i' b Hii' H0.
+  case: mem' H0 => init_ data_.
+  rewrite /mem_update /mem_lookup.
+  case_eq (N.ltb i' (N.of_nat (length (ml_data mem)))); last by discriminate.
+  move => Hlen [Hinit Hdata] /=.
+  rewrite Hdata => {Hdata}.
+  apply: bar.
+  lia.
+  apply N.ltb_lt in Hlen.
+  lia.
 Qed.
 
 Lemma memory_list_ax_length_constant_update :
   Memory.mem_ax_length_constant_update memory_list mem_make mem_length mem_grow mem_lookup mem_update.
 Proof.
-move => i b [dv_init1 dv_list1] [dv_init2 dv_list2].
-rewrite /mem_update /mem_length /=.
-case_eq (N.ltb i (N.of_nat (length dv_list1))); last by discriminate.
-move => Hlen [Hinit Hlist].
-apply N.ltb_lt in Hlen.
-rewrite Hlist.
-f_equal.
-apply: (split_preserves_length _ (N.to_nat i) b dv_list1).
-lia.
+  move => i b [dv_init1 dv_list1] [dv_init2 dv_list2].
+  rewrite /mem_update /mem_length /=.
+  case_eq (N.ltb i (N.of_nat (length dv_list1))); last by discriminate.
+  move => Hlen [Hinit Hlist].
+  apply N.ltb_lt in Hlen.
+  rewrite Hlist.
+  f_equal.
+  apply: (split_preserves_length _ (N.to_nat i) b dv_list1).
+  lia.
 Qed.
-
 
 Require Import bytes common.
 From HB Require Import structures.
@@ -184,10 +183,6 @@ Definition eqmemory_listP : Equality.axiom memory_list_eqb :=
 
 HB.instance Definition memory_list_eqMixin := hasDecEq.Build memory_list eqmemory_listP.
 
-(*
-Canonical Structure memory_list_eqMixin := EqMixin eqmemory_listP.
-Canonical Structure memory_list_eqType := Eval hnf in EqType memory_list memory_list_eqMixin.
-*)
 Definition list_memoryMixin :=
   Memory.Mixin
     memory_list_ax_lookup_out_of_bounds
@@ -195,7 +190,3 @@ Definition list_memoryMixin :=
     memory_list_ax_lookup_update
     memory_list_ax_lookup_skip
     memory_list_ax_length_constant_update.
-(*
-Definition list_memoryClass := Memory.Class memory_list_eqMixin list_memoryMixin.
-Canonical list_memoryType := @Memory.Pack memory_list list_memoryClass.
-*)

--- a/theories/numerics.v
+++ b/theories/numerics.v
@@ -95,18 +95,6 @@ Record mixin_of (int_t : Type) := Mixin {
 Definition int_ne (int_t: Type) (mx: mixin_of int_t) : int_t -> int_t -> bool :=
   fun x y => negb (int_eq mx x y).
 
-(*
-Record class_of T := Class { base : Equality.class_of T; mixin : mixin_of T }.
-Local Coercion base : class_of >-> Equality.class_of.
-
-Structure type := Pack {sort : Type; _ : class_of sort}.
-Local Coercion sort : type >-> Sortclass.
-
-Definition int_ne (e : type) : sort e -> sort e -> bool :=
-  let 'Pack _ (Class _ m) := e in
-    fun x => fun y => negb (int_eq m x y).
-*)
-
 (** ** Definitions **)
 
 Module Make (WS: Integers.WORDSIZE).
@@ -1034,18 +1022,7 @@ Proof.
   move=> [i ?] /=. rewrite Coqlib.Z_to_nat_max. by rewrite Z.max_l; lias.
 Qed.
 
-(*
-Definition cT : Equality.type := Equality.Pack {| base := EqMixin eq_eqP; mixin := Tmixin |}.
-
-Definition class := let: Pack _ c as cT' := cT return class_of cT' in c.
-Definition clone c of phant_id class c := @Pack T c.
-Local Definition xT := let: Pack T _ := cT in T.
-Notation xclass := (class : class_of xT).
-
-Definition pack m :=
-  fun b bT & phant_id (Equality.class bT) b => Pack (@Class T b m).
- *)
-(* TODO: redundant? *)
+(* redundant redirections? *)
 Definition eqType := T.
 
 Definition eq_mixin := Tmixin.
@@ -1073,15 +1050,6 @@ HB.instance Definition i32_eqMixin := hasDecEq.Build i32 Wasm_int.Int32.eq_eqP.
 Definition i64 : Type :=  Wasm_int.Int64.T.
 Definition i64m := Wasm_int.Int64.Tmixin.
 HB.instance Definition i64_eqMixin := hasDecEq.Build i64 Wasm_int.Int64.eq_eqP.
-
-(*
-Definition i32r : Wasm_int.class_of i32 := Wasm_int.Int32.class.
-Definition i32t : Wasm_int.type := Wasm_int.Pack i32r.
-Definition i32m := Wasm_int.mixin i32r.
-Definition i64r : Wasm_int.class_of i64 := Wasm_int.Int64.class.
-Definition i64t : Wasm_int.type := Wasm_int.Pack i64r.
-Definition i64m := Wasm_int.mixin i64r.
-*)
 
 Definition wasm_wrap (i : i64) : i32 :=
   @Wasm_int.int_of_Z i32 i32m (Wasm_int.Z_of_uint i64m i).
@@ -1148,18 +1116,6 @@ Record mixin_of (float_t : Type) := Mixin {
 
 Definition float_ne (float_t: Type) (mx: mixin_of float_t) : float_t -> float_t -> bool :=
   fun x y => negb (float_eq mx x y).
-
-(*
-Record class_of T := Class { base : Equality.class_of T; mixin : mixin_of T }.
-Local Coercion base : class_of >-> Equality.class_of.
-
-Structure type := Pack {sort; _ : class_of sort}.
-Local Coercion sort : type >-> Sortclass.
-
-Definition float_ne (e : type) : sort e -> sort e -> bool :=
-  let 'Pack _ (Class _ m) := e in
-    fun x => fun y => negb (float_eq m x y).
-*)
 
 (** ** Architectures **)
 
@@ -1899,17 +1855,6 @@ Definition Tmixin : mixin_of T := {|
     float_convert_si64 := convert_si64 ;
   |}.
 
-(*
-Definition cT : type := Pack {| base := T_eqMixin; mixin := Tmixin |}.
-
-Definition class := let: Pack _ c as cT' := cT return class_of cT' in c.
-Definition clone c of phant_id class c := @Pack T c.
-Local Definition xT := let: Pack T _ := cT in T.
-Notation xclass := (class : class_of xT).
-
-Definition pack m :=
-  fun b bT & phant_id (Equality.class bT) b => Pack (@Class T b m).
-*)
 Definition eqType := T.
 
 End Make.

--- a/theories/opsem.v
+++ b/theories/opsem.v
@@ -34,10 +34,10 @@ Inductive reduce_simple : seq administrative_instruction -> seq administrative_i
   (** testops **)
   | rs_testop_i32 :
     forall c testop,
-    reduce_simple [::$VN (VAL_int32 c); AI_basic (BI_testop T_i32 testop)] [::$VN (VAL_int32 (wasm_bool (@app_testop_i i32t testop c)))]
+    reduce_simple [::$VN (VAL_int32 c); AI_basic (BI_testop T_i32 testop)] [::$VN (VAL_int32 (wasm_bool (app_testop_i i32m testop c)))]
   | rs_testop_i64 :
     forall c testop,
-    reduce_simple [::$VN (VAL_int64 c); AI_basic (BI_testop T_i64 testop)] [::$VN (VAL_int32 (wasm_bool (@app_testop_i i64t testop c)))]
+    reduce_simple [::$VN (VAL_int64 c); AI_basic (BI_testop T_i64 testop)] [::$VN (VAL_int32 (wasm_bool (app_testop_i i64m testop c)))]
 
   (** relops **)
   | rs_relop: forall v1 v2 t op,

--- a/theories/type_checker.v
+++ b/theories/type_checker.v
@@ -1,5 +1,6 @@
 (** Wasm type checker **)
 From mathcomp Require Import ssreflect ssrfun ssrnat ssrbool eqtype seq.
+From HB Require Import structures.
 From Wasm Require Export typing datatypes_properties operations.
 From Coq Require Import BinNat.
 
@@ -23,8 +24,7 @@ Definition checker_type_eqb v1 v2 : bool := checker_type_eq_dec v1 v2.
 Definition eqchecker_typeP : Equality.axiom checker_type_eqb :=
   eq_dec_Equality_axiom checker_type_eq_dec.
 
-Canonical Structure checker_type_eqMixin := EqMixin eqchecker_typeP.
-Canonical Structure checker_type_eqType := Eval hnf in EqType checker_type checker_type_eqMixin.
+HB.instance Definition checker_type_eqMixin := hasDecEq.Build checker_type eqchecker_typeP.
 
 Fixpoint consume (ct: checker_type) (cons : list value_type) : option checker_type :=
   match cons with

--- a/theories/type_checker_reflects_typing.v
+++ b/theories/type_checker_reflects_typing.v
@@ -1511,8 +1511,7 @@ Proof.
     assert (b_e_type_checker C bes (Tf tn tm)) as H; (try by rewrite H in Htc_bool); clear Htc_bool.
     induction Hbet; subst => //=; (try rewrite H); unfold type_update, type_update_top, produce; simplify_tc_goal; (try by unfold c_types_agree in *; simplify_tc_goal).
     (* Ref_func *)
-    + (* inP is slightly stupid *)
-      move/(@inP u32_eqType) in H0.
+    + move/inP in H0.
       by rewrite H0.
     + rewrite value_type_select_refl => //.
       unfold c_types_agree.


### PR DESCRIPTION
Fixes for updating to MathComp 2.x.

No changes should be required for downstream uses except for using the mixins instead of the packed eqTypes in numeric operations, the latter of which are no longer required in MathComp 2.x (e.g. `i32m` instead of `i32t` as the argument of `app_binop`).