### PR TITLE
memory type class: more properties

### DIFF
--- a/theories/memory.v
+++ b/theories/memory.v
@@ -26,7 +26,12 @@ Section Memory.
       (* Doesn't have to succeed *)
       mem_grow : N -> mem_t -> option mem_t;
       mem_update : N -> byte -> mem_t -> option mem_t;
-      
+
+      mem_lookup_ib :
+      forall mem i,
+        N.lt i (mem_length mem) ->
+        mem_lookup i mem <> None;
+
       mem_lookup_oob :
       forall mem i,
         N.ge i (mem_length mem) ->
@@ -56,6 +61,16 @@ Section Memory.
       forall i b mem mem',
         mem_update i b mem = Some mem' ->
         mem_length mem' = mem_length mem;
+
+      mem_update_ib :
+      forall mem i b,
+        N.lt i (mem_length mem) ->
+        mem_update i b mem <> None;
+
+      mem_update_oob :
+      forall mem i b,
+        N.ge i (mem_length mem) ->
+        mem_update i b mem = None;
 
       mem_grow_lookup :
       forall i n mem mem',

--- a/theories/memory_list.v
+++ b/theories/memory_list.v
@@ -47,6 +47,18 @@ Section MemoryList.
                 |}
       else None.
 
+  Lemma ml_lookup_ib:
+    forall mem i,
+      (i < ml_length mem)%N ->
+      ml_lookup i mem <> None.
+  Proof.
+    move => mem i => /=.
+    rewrite /ml_length /ml_lookup.
+    move => H.
+    apply N.ltb_lt in H.
+    by rewrite H.
+  Qed.
+
   Lemma ml_lookup_oob:
     forall mem i,
       (i >= ml_length mem)%N ->
@@ -151,6 +163,32 @@ Proof.
   by lias.
 Qed.
 
+Lemma ml_update_ib:
+  forall mem i b,
+    (i < ml_length mem)%N ->
+    ml_update i b mem <> None.
+Proof.
+  move => mem i b => /=.
+  rewrite /ml_length /ml_update.
+  move => H.
+  apply N.ltb_lt in H.
+  by rewrite H.
+Qed.
+
+Lemma ml_update_oob:
+  forall mem i b,
+    (i >= ml_length mem)%N ->
+    ml_update i b mem = None.
+Proof.
+  move => mem i b => /=.
+  rewrite /ml_length /ml_update.
+  move => H.
+  apply N.ge_le in H; move/N.leb_spec0 in H.
+  rewrite N.leb_antisym in H.
+  move/negPf in H.
+  by rewrite H.
+Qed.
+
 Lemma ml_grow_lookup :
   forall i n mem mem',
     (i < ml_length mem)%N ->
@@ -174,12 +212,15 @@ Qed.
   Instance Memory_list: Memory.
 Proof.
   apply (@Build_Memory memory_list ml_make ml_length ml_lookup ml_grow ml_update).
+  - exact ml_lookup_ib.
   - exact ml_lookup_oob.
   - exact ml_make_length.
   - exact ml_make_lookup.
   - exact ml_update_lookup.
   - exact ml_update_lookup_ne.
   - by intros; eapply ml_update_length; eauto.
+  - exact ml_update_ib.
+  - exact ml_update_oob.
   - exact ml_grow_lookup.
   - exact ml_grow_length.
 Qed.

--- a/theories/memory_vec.v
+++ b/theories/memory_vec.v
@@ -229,6 +229,18 @@ Section MemoryVec.
   Definition mv_update i b v:= @vector_update byte v i b.
   Definition mv_grow n v:= @vector_grow byte v n.
 
+  Lemma mv_lookup_ib:
+    forall mem i,
+      (i < mv_length mem)%N ->
+      mv_lookup i mem <> None.
+  Proof.
+    move => mem i => /=.
+    rewrite /mv_length /mv_lookup /vector_lookup.
+    move => H.
+    apply N.ltb_lt in H.
+    by rewrite H.
+  Qed.
+
   Lemma mv_lookup_oob:
     forall mem i,
       (i >= mv_length mem)%N ->
@@ -345,7 +357,33 @@ Proof.
   generalize ((vector_length mem + n) <=? v_capacity mem) at 2 3.
   case => Hgrow //=; move => [<-] => /=; done.
 Qed.
-  
+
+Lemma mv_update_ib:
+  forall mem i b,
+    (i < mv_length mem)%N ->
+    mv_update i b mem <> None.
+Proof.
+  move => mem i b => /=.
+  rewrite /mv_length /mv_update /vector_update.
+  move => H.
+  apply N.ltb_lt in H.
+  by rewrite H.
+Qed.
+
+Lemma mv_update_oob:
+  forall mem i b,
+    (i >= mv_length mem)%N ->
+    mv_update i b mem = None.
+Proof.
+  move => mem i b => /=.
+  rewrite /mv_length /mv_update /vector_update.
+  move => H.
+  apply N.ge_le in H; move/N.leb_spec0 in H.
+  rewrite N.leb_antisym in H.
+  move/negPf in H.
+  by rewrite H.
+Qed.
+
 Lemma mv_grow_lookup :
   forall i n mem mem',
     (i < mv_length mem)%N ->
@@ -396,12 +434,15 @@ Qed.
   Instance Memory_vec: Memory.
 Proof.
   apply (@Build_Memory memory_vec mv_make mv_length mv_lookup mv_grow mv_update).
+  - exact mv_lookup_ib.
   - exact mv_lookup_oob.
   - exact mv_make_length.
   - exact mv_make_lookup.
   - exact mv_update_lookup.
   - exact mv_update_lookup_ne.
   - by intros; eapply mv_update_length; eauto.
+  - exact mv_update_ib.
+  - exact mv_update_oob.
   - exact mv_grow_lookup.
   - exact mv_grow_length.
 Qed.


### PR DESCRIPTION
hey @raoxiaojia,
CertiCoq-Wasm is now on the current version of WasmCert (this branch).
For the update, I extended the memory type class with a few additional properties.

- mem_lookup in bounds
- mem_update in bounds
- mem_update out of bounds