### PR TITLE
[DO NOT MERGE] Port to Rocq master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         opam_file:
           - 'coq-wasm.opam'
         coq_version:
-          - '9.0'
+          - 'dev'
       fail-fast: true
 
     steps:

--- a/coq-wasm.opam
+++ b/coq-wasm.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "2.2.1"
+version: "dev"
 synopsis: "Wasm formalisation in Coq"
 description:
   "Wasm formalisation in Coq, following the AFP formalisation of Conrad Watt"
@@ -12,10 +12,10 @@ homepage: "https://github.com/WasmCert/WasmCert-Coq"
 bug-reports: "https://github.com/WasmCert/WasmCert-Coq/issues"
 depends: [
   "dune" {>= "3.17"}
-  "coq" {>= "9.0" & < "9.2~"}
-  "coq-compcert" {>= "3.14"}
-  "coq-ext-lib" {>= "0.11.8"}
-  "coq-mathcomp-ssreflect" {>= "2.4.0" & <= "2.5~"}
+  "coq" {= "dev"}
+  "coq-compcert" {= "dev"}
+  "coq-ext-lib" {= "dev"}
+  "coq-mathcomp-ssreflect" {= "dev"}
   "rocq-parseque" {>= "0.2.0"}
   "cmdliner" {>= "1.1.0"}
   "mdx" {>= "1.9.0" & with-test}

--- a/theories/common.v
+++ b/theories/common.v
@@ -6,6 +6,8 @@ From mathcomp Require Import ssreflect ssrnat ssrbool seq eqtype.
 From compcert Require Integers.
 From HB Require Import structures.
 
+#[global] Set SsrOldRewriteGoalsOrder.
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/theories/contexts.v
+++ b/theories/contexts.v
@@ -1101,6 +1101,7 @@ Definition reduce_ctx (hs hs': host_state) (cfg cfg': cfg_tuple_ctx) : Prop :=
       end
   | None => False
   end.
+#[global] Set SsrOldRewriteGoalsOrder.
 
 (** ctx reduction lemmas **)
 (* ctxs reduction can be focused in any partial initial fragments with a pivot cc. *)
@@ -1121,8 +1122,8 @@ Proof.
     unfold reduce_ctx, ctx_to_cfg in * => /=.
     destruct cc as [[fvs0 fk0 ff0 fes0] lcs0].
     rewrite rev_cat rev_cons rev_rcons /=.
-    repeat rewrite rev_cat rev_rcons revK.
-    rewrite rev_cat rev_cons rev_rcons revK /= rev_cat rev_rcons revK revK.
+    rewrite rev_cat rev_cons rev_rcons /= rev_cat revK rev_rcons revK.
+    rewrite rev_cat revK rev_rcons revK.
     apply (list_label_ctx_eval.(ctx_reduce)) => //.
     do 2 rewrite foldl_cat.
     simpl in *.

--- a/theories/numerics.v
+++ b/theories/numerics.v
@@ -7,6 +7,8 @@ From compcert Require Integers Floats.
 From mathcomp Require Import ssreflect ssrfun ssrnat ssrbool eqtype seq.
 From HB Require Import structures.
 
+Set SsrOldRewriteGoalsOrder.
+
 From Flocq Require Import Core.
 
 Set Implicit Arguments.
@@ -1449,7 +1451,7 @@ Definition opp : T -> T := Binary.Bopp _ _ wasm_opp_nan.
   The sign is not specified if given 0 as a mantissa. **)
 Definition normalise (m e : Z) : T :=
   Binary.binary_normalize _ _ prec_gt_0 Hmax
-    BinarySingleNaN.mode_NE m e ltac:(abstract exact false).
+    BinarySingleNaN.mode_NE m e false.
 
 (** As Flocq is unfortunately undocumented, let us introduce a unit test here, to check
   that indeed we have the correct understanding of definitions.
@@ -1578,9 +1580,7 @@ Definition BofZ : Z -> T :=
 (** [BofZ] is actually just the same thing than calling [normalise] with an empty exponent. **)
 Lemma BofZ_normalise : forall i, BofZ i = normalise i 0.
 Proof.
-  rewrite /BofZ /IEEE754_extra.BofZ /normalise => i.
-  f_equal; apply: Logic.Eqdep_dec.eq_proofs_unicity_on;
-    move=> c; case: c; by [ left | right ]. (* LATER: Remove this bruteforce. *)
+  rewrite /BofZ /IEEE754_extra.BofZ /normalise => i //.
 Qed.
 
 (** We can then define versions of these operators directly from float to float,


### PR DESCRIPTION
This PR adapts the proof scripts to latest Rocq / mathcomp master. I propose it because I would like to put CertiRocq in the CI, which has a Wasm backend relying on WasmCert. That would hence mean putting WasmCert in the CI as well. Are you ok/interested in that? The usual setup for Rocq projects in Rocq's CI is to have the `master` branch follow Rocq master, with potentially different branches like 9.0, 9.1 etc if code needs to be version specific. One can also use a specific e.g. `rocq-master` branch solely used for the Rocq CI, and periodically update it from one's master branch that rather depends on a released Rocq (easier for contributors). For these particular changes (due to SsrOldRewriteOrder changing in mathcomp master and the upcoming mathcomp release), I think it should be backwards compat (although the `rewrite` change in contexts.v seems a bit more subtle).